### PR TITLE
honor the vagrant box version

### DIFF
--- a/lib/vagrant-libvirt/action/handle_box_image.rb
+++ b/lib/vagrant-libvirt/action/handle_box_image.rb
@@ -35,7 +35,7 @@ module VagrantPlugins
           config   = env[:machine].provider_config
           box_image_file = env[:machine].box.directory.join('box.img').to_s
           env[:box_volume_name] = env[:machine].box.name.to_s.dup.gsub("/", "-VAGRANTSLASH-")
-          env[:box_volume_name] << '_vagrant_box_image.img'
+          env[:box_volume_name] << "_vagrant_box_image_#{env[:machine].box.version.to_s}.img"
 
           @@lock.synchronize do
             # Don't continue if image already exists in storage pool.


### PR DESCRIPTION
As discussed in #85 vagrant-libvirt's image management could
be better. This is only addressing a small aspect of the topic,
but due to its simplicity it could improve vagrant-libvirt in the
meantime until #85 is fully resolved.