### PR TITLE
Vagrant-libvirt fails to get IP with libvirt-1.2.11

### DIFF
--- a/lib/vagrant-libvirt/action/connect_libvirt.rb
+++ b/lib/vagrant-libvirt/action/connect_libvirt.rb
@@ -30,7 +30,7 @@ module VagrantPlugins
 
           # Setup command for retrieving IP address for newly created machine
           # with some MAC address. Get it from dnsmasq leases table
-          ip_command = %q[ find /var/lib/libvirt/dnsmasq/ /var/lib/misc/ -name '*leases' -exec grep $mac {} \; | cut -d' ' -f3 ]
+          ip_command = %q[ arp -n | grep $mac | cut -d' ' -f 1 ]
           conn_attr[:libvirt_ip_command] = ip_command
 
           @logger.info("Connecting to Libvirt (#{uri}) ...")

--- a/lib/vagrant-libvirt/action/connect_libvirt.rb
+++ b/lib/vagrant-libvirt/action/connect_libvirt.rb
@@ -30,7 +30,7 @@ module VagrantPlugins
 
           # Setup command for retrieving IP address for newly created machine
           # with some MAC address. Get it from dnsmasq leases table
-          ip_command = %q[ arp -n | grep $mac | cut -d' ' -f 1 ]
+          ip_command = %q[ grep $mac /proc/net/arp | awk '{print $1}' ]
           conn_attr[:libvirt_ip_command] = ip_command
 
           @logger.info("Connecting to Libvirt (#{uri}) ...")

--- a/lib/vagrant-libvirt/action/connect_libvirt.rb
+++ b/lib/vagrant-libvirt/action/connect_libvirt.rb
@@ -30,7 +30,7 @@ module VagrantPlugins
 
           # Setup command for retrieving IP address for newly created machine
           # with some MAC address. Get it from dnsmasq leases table
-          ip_command = %q[ grep $mac /proc/net/arp | awk '{print $1}' ]
+          ip_command = %q[ awk "/$mac/ {print \$1}" /proc/net/arp ]
           conn_attr[:libvirt_ip_command] = ip_command
 
           @logger.info("Connecting to Libvirt (#{uri}) ...")


### PR DESCRIPTION
libvirt moved away from using the leases file to track dnsmasq leases. [1][1]
With libvirt 1.2.11, a custom file named `<interface>.status` inside `/var/lib/libvirt` is used instead.
Because of this change, a `vagrant up` hangs indefinitely waiting for IP.

I'm currently working around this issue by downgrading libvirt (1.2.10). If you need any more details, I'll be happy to help.

I'm filing this here, because I kind of remember that vagrant-libvirt was looking up the ip by itself, instead of using fog. If this is no longer correct, please let me know where I need to file this issue.

System Info:
Archlinux 
libvirt 1.2.11-1
vagrant 1.7.2
vagrant-libvirt 0.0.24

[1]: http://libvirt.org/git/?p=libvirt.git;a=commit;h=0f87054b61d73493fb505ecb97bd16615bc53699