### PR TITLE
Update README with Bundler version

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,10 +354,12 @@ The box is a tarball containing:
 
 ## Development
 
-To work on the `vagrant-libvirt` plugin, clone this repository out, and use
-[Bundler](http://gembundler.com) to get the dependencies:
+To work on the `vagrant-libvirt` plugin, install
+[Bundler](http://gembundler.com), clone this repository out, and
+use Bundler to get the dependencies:
 
 ```
+$ sudo gem install bundler --version '<1.8.0'
 $ git clone https://github.com/pradels/vagrant-libvirt.git
 $ cd vagrant-libvirt
 $ bundle install


### PR DESCRIPTION
I was getting the following error, using the latest version (1.8.2) of Bundler

```shell
~/projects/vagrant-libvirt(branch:master) » bundler install
Your Gemfile lists the gem vagrant-libvirt (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
Fetching gem metadata from https://rubygems.org/.........
Fetching version metadata from https://rubygems.org/..
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    vagrant (>= 0) ruby depends on
      bundler (< 1.8.0, >= 1.5.2) ruby

  Current Bundler version:
    bundler (1.8.2)

This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?
```

Installing an older version fixes this:
```
sudo gem install bundler --version '<1.8.0'
```
In addition, I also had to ```apt-get install ruby-dev``` for install to work on Ubuntu 14.04.