### PR TITLE
Update README: Ruby 2.0 required

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ $ git clone https://github.com/pradels/vagrant-libvirt.git
 $ cd vagrant-libvirt
 $ bundle install
 ```
+Ruby >= 2.0 is needed.
 
 Once you have the dependencies, verify the unit tests pass with `rake`:
 


### PR DESCRIPTION
Can't use my Ubuntu 14.04 bundled Ruby 1.9.3. Make a note about 2.0