### PR TITLE
Multiple disks in different provider call fails.

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -107,11 +107,10 @@ module VagrantPlugins
         @video_vram        = UNSET_VALUE
 
         # Storage
-        @disks             = UNSET_VALUE
+        @disks             = []
       end
 
       def _get_device(disks)
-        disks = [] if disks == UNSET_VALUE
         # skip existing devices and also the first one (vda)
         exist = disks.collect {|x| x[:device]}+[1.vdev.to_s]
         skip = 1		# we're 1 based, not 0 based...
@@ -133,9 +132,6 @@ module VagrantPlugins
           :path => nil,
           :bus => 'virtio'
         }.merge(options)
-
-        #puts "storage(#{storage_type} --- #{options.to_s})"
-        @disks = [] if @disks == UNSET_VALUE
 
         disk = {
           :device => options[:device],
@@ -237,9 +233,6 @@ module VagrantPlugins
         @graphics_ip = '127.0.0.1' if @graphics_ip == UNSET_VALUE
         @video_type = 'cirrus' if @video_type == UNSET_VALUE
         @video_vram = 9216 if @video_vram == UNSET_VALUE
-
-        # Storage
-        @disks = [] if @disks == UNSET_VALUE
       end
 
       def validate(machine)
@@ -254,7 +247,13 @@ module VagrantPlugins
          { "Libvirt Provider" => errors }
       end
 
+      def merge(other)
+        super.tap do |result|
+          c = disks.dup
+          c += other.disks
+          result.disks = c
+        end
+      end
     end
   end
 end
-


### PR DESCRIPTION
This

```ruby
Vagrant.configure("2") do |c|
  c.vm.box = "centos-7.0"
  c.vm.hostname = "default-centos-70.vagrantup.com"
  c.vm.provider :libvirt do |p|
    p.storage :file, :size => "5M", :path => "vagrant_vdb.qcow2", :device => "vdb"
    p.storage :file, :size => "5M", :path => "vagrant_vdc.qcow2", :device => "vdc"
  end
end
```

works.

But this fails:

```ruby
def add_block_device(node, port, size)
  node.vm.provider 'libvirt' do |lv|
    port_name = ('b'..'z').to_a[port-1]
    lv.storage :file, :size => "#{size}M", :path => "vagrant_#{node.vm.hostname}_vd#{port_name}.qcow2", :device => "vd#{port_name}"
  end
end

Vagrant.configure("2") do |c|
  c.vm.box = "centos-7.0"
  c.vm.hostname = "default-centos-70.vagrantup.com"
  add_block_device(c, 1, 5)
  add_block_device(c, 2, 5)
end
```

In the second case only the last disk is added:

```
==> default:  -- Disks:         vdc(qcow2,5M)
==> default:  -- Disk(vdc):     /var/lib/libvirt/images/vagrant_default-centos-70.vagrantup.com_vdc.qcow2
```

This patch corrects this.  It is done as the `customize` configuration
is the vagrant code.