### PR TITLE
Increase the domain wait_for timeout

### DIFF
--- a/lib/vagrant-libvirt/action/read_ssh_info.rb
+++ b/lib/vagrant-libvirt/action/read_ssh_info.rb
@@ -32,7 +32,7 @@ module VagrantPlugins
 
           # Get IP address from dnsmasq lease file.
           ip_address = nil
-          domain.wait_for(2) {
+          domain.wait_for(10) {
             addresses.each_pair do |type, ip|
               ip_address = ip[0] if ip[0] != nil
             end

--- a/lib/vagrant-libvirt/action/read_ssh_info.rb
+++ b/lib/vagrant-libvirt/action/read_ssh_info.rb
@@ -32,7 +32,7 @@ module VagrantPlugins
 
           # Get IP address from dnsmasq lease file.
           ip_address = nil
-          domain.wait_for(10) {
+          domain.wait_for(60) {
             addresses.each_pair do |type, ip|
               ip_address = ip[0] if ip[0] != nil
             end


### PR DESCRIPTION
This provides a more reasonable length of time to achieve an SSH
connection on a loaded system. 2 seconds is not enough.