### PR TITLE
Add 'machine_type' parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ end
 * `graphics_passwd` - Sets the password for the display protocol. Working for vnc and spice. by default working without passsword.
 * `video_type` - Sets the graphics card type exposed to the guest.  Defaults to "cirrus".  [Possible values](http://libvirt.org/formatdomain.html#elementsVideo) are "vga", "cirrus", "vmvga", "xen", "vbox", or "qxl".
 * `video_vram` - Used by some graphics card types to vary the amount of RAM dedicated to video.  Defaults to 9216.
+* `machine` - Sets machine type. Equivalent to qemu `-machine`. Use `qemu-system-x86_64 -machine help` to get a list of supported machines.
 
 
 Specific domain settings can be set for each domain separately in multi-VM

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -28,6 +28,7 @@ module VagrantPlugins
           @name = env[:domain_name]
           @cpus = config.cpus.to_i
           @cpu_mode = config.cpu_mode
+          @machine_type = config.machine_type
           @disk_bus = config.disk_bus
           @nested = config.nested
           @memory_size = config.memory.to_i*1024

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -55,6 +55,7 @@ module VagrantPlugins
       attr_accessor :memory
       attr_accessor :cpus
       attr_accessor :cpu_mode
+      attr_accessor :machine_type
       attr_accessor :disk_bus
       attr_accessor :nic_model_type
       attr_accessor :nested
@@ -91,6 +92,7 @@ module VagrantPlugins
         @memory            = UNSET_VALUE
         @cpus              = UNSET_VALUE
         @cpu_mode          = UNSET_VALUE
+        @machine_type      = UNSET_VALUE
         @disk_bus          = UNSET_VALUE
         @nic_model_type    = UNSET_VALUE
         @nested            = UNSET_VALUE
@@ -219,6 +221,7 @@ module VagrantPlugins
         @memory = 512 if @memory == UNSET_VALUE
         @cpus = 1 if @cpus == UNSET_VALUE
         @cpu_mode = 'host-model' if @cpu_mode == UNSET_VALUE
+        @machine_type = nil if @machine_type == UNSET_VALUE
         @disk_bus = 'virtio' if @disk_bus == UNSET_VALUE
         @nic_model_type = 'virtio' if @nic_model_type == UNSET_VALUE
         @nested = false if @nested == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -14,7 +14,11 @@
   <% end %>
 
   <os>
+  <% if @machine_type %>
+    <type machine='<%= @machine_type %>'>hvm</type>
+  <% else %>
     <type>hvm</type>
+  <% end %>
     <boot dev='hd'/>
     <kernel><%= @kernel %></kernel>
     <initrd><%= @initrd %></initrd>


### PR DESCRIPTION
This parameter will be used by libvirt to set the machine type qemu will
use.  For example, setting it to `pc-1.0` will generate this `os`
definition:

    <os>
      <type arch='x86_64' machine='pc-1.0'>hvm</type>
    </os>