### PR TITLE
Support for local cdrom storage in vagrant-libvirt

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -20,6 +20,10 @@ module VagrantPlugins
           return disks.collect{ |x| x[:device]+'('+x[:type]+','+x[:size]+')' }.join(', ')
         end
 
+        def _cdroms_print(cdroms)
+          return cdroms.collect{ |x| x[:dev] }.join(', ')
+        end
+
         def call(env)
           # Get config.
           config = env[:machine].provider_config
@@ -52,7 +56,7 @@ module VagrantPlugins
           # Storage
           @storage_pool_name = config.storage_pool_name
           @disks = config.disks
-		  @cdrom = config.cdrom
+          @cdroms = config.cdroms
 
           config = env[:machine].provider_config
           @domain_type = config.driver
@@ -122,7 +126,13 @@ module VagrantPlugins
           @disks.each do |disk|
             env[:ui].info(" -- Disk(#{disk[:device]}):     #{disk[:absolute_path]}")
           end
-          env[:ui].info(" -- CDROM:             #{@cdrom}")
+
+          if @cdroms.length > 0
+            env[:ui].info(" -- CDROMS:            #{_cdroms_print(@cdroms)}")
+          end
+          @cdroms.each do |cdrom|
+            env[:ui].info(" -- CDROM(#{cdrom[:dev]}):     #{cdrom[:path]}")
+          end
           env[:ui].info(" -- Command line : #{@cmd_line}")
 
           # Create libvirt domain.

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -52,6 +52,7 @@ module VagrantPlugins
           # Storage
           @storage_pool_name = config.storage_pool_name
           @disks = config.disks
+		  @cdrom = config.cdrom
 
           config = env[:machine].provider_config
           @domain_type = config.driver
@@ -121,6 +122,7 @@ module VagrantPlugins
           @disks.each do |disk|
             env[:ui].info(" -- Disk(#{disk[:device]}):     #{disk[:absolute_path]}")
           end
+          env[:ui].info(" -- CDROM:             #{@cdrom}")
           env[:ui].info(" -- Command line : #{@cmd_line}")
 
           # Create libvirt domain.

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -131,7 +131,7 @@ module VagrantPlugins
             env[:ui].info(" -- CDROMS:            #{_cdroms_print(@cdroms)}")
           end
           @cdroms.each do |cdrom|
-            env[:ui].info(" -- CDROM(#{cdrom[:dev]}):     #{cdrom[:path]}")
+            env[:ui].info(" -- CDROM(#{cdrom[:dev]}):        #{cdrom[:path]}")
           end
           env[:ui].info(" -- Command line : #{@cmd_line}")
 

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -48,6 +48,15 @@
 -%>
     </disk>
 <% end -%>
+
+<% if @cdrom %>
+    <disk type='file' device='cdrom'>
+      <source file='<%= @cdrom[:path] %>'/>
+      <target dev='<%= @cdrom[:dev] %>' bus='<%= @cdrom[:bus] %>'/>
+      <readonly/>
+    </disk>
+<% end %>
+
     <serial type='pty'>
       <target port='0'/>
     </serial>

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -49,10 +49,10 @@
     </disk>
 <% end -%>
 
-<% if @cdrom %>
+<% @cdroms.each do |c| %>
     <disk type='file' device='cdrom'>
-      <source file='<%= @cdrom[:path] %>'/>
-      <target dev='<%= @cdrom[:dev] %>' bus='<%= @cdrom[:bus] %>'/>
+      <source file='<%= c[:path] %>'/>
+      <target dev='<%= c[:dev] %>' bus='<%= c[:bus] %>'/>
       <readonly/>
     </disk>
 <% end %>


### PR DESCRIPTION
Support for local cdrom storage using:

    config.vm.provider :libvirt do |libvirt|
        libvirt.storage :file, :device => :cdrom, :path => "/some/path/to/cdrom.iso"
    end