### PR TITLE
Fixes for id_ssh_key_file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Although it should work without any configuration for most people, this provider
 * `connect_via_ssh` - If use ssh tunnel to connect to Libvirt.
 * `username` - Username and password to access Libvirt.
 * `password` - Password to access Libvirt.
-* `id_ssh_key_file` - The id ssh key file name to access Libvirt (eg: id_dsa or id_rsa or ... in the user .ssh directory)
+* `id_ssh_key_file` - If not nil, uses this ssh private key to access Libvirt. Default is $HOME/.ssh/id_rsa. Prepends $HOME/.ssh/ if no directory.  
 * `socket` - Path to the libvirt unix socket (eg: /var/run/libvirt/libvirt-sock)
 * `uri` - For advanced usage. Directly specifies what libvirt connection URI vagrant-libvirt should use. Overrides all other connection configuration options.
 

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -245,8 +245,10 @@ module VagrantPlugins
 
         if @id_ssh_key_file
           # set ssh key for access to libvirt host
-          home_dir = `echo ${HOME}`.chomp
-          uri << "\&keyfile=#{home_dir}/.ssh/"+@id_ssh_key_file
+          uri << "\&keyfile="
+          # if no slash, prepend $HOME/.ssh/
+          uri << "#{`echo ${HOME}`.chomp}/.ssh/" if @id_ssh_key_file !~ /\//
+          uri << @id_ssh_key_file
         end
         # set path to libvirt socket
         uri << "\&socket="+@socket if @socket


### PR DESCRIPTION
Don't prepend ~/.ssh/ if @id_ssh_key_file includes a directory
Improved doc for id_ssh_key_file. 

See open issue here:
https://github.com/pradels/vagrant-libvirt/issues/335

Note, I'd prefer that @id_ssh_key_file defaulted to nil but I didn't make that change since it would likely break existing libvirt Vagrantfiles.