### PR TITLE
Depend on new extracted fog-libvirt gem

### DIFF
--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -20,10 +20,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec-expectations", "~> 2.12.1"
   gem.add_development_dependency "rspec-mocks", "~> 2.12.1"
 
-  gem.add_runtime_dependency 'fog', '~> 1.15'
-  gem.add_runtime_dependency 'ruby-libvirt', '~> 0.4'
+  gem.add_runtime_dependency 'fog-libvirt', '~> 0.0.1'
   gem.add_runtime_dependency 'nokogiri', '~> 1.6.0'
 
   gem.add_development_dependency 'rake'
 end
-


### PR DESCRIPTION
(And depend on ruby-libvirt library through fog-libvirt.)

Hi, I am working with `fog` upstream on `fog-libvirt` extraction so we don't have to carry so many unused dependencies in vagrant-libvirt. As the first version is released, it would be nice to incorporate it in master and find possible issues.