### PR TITLE
Wait for libvirt to shutdown the domain

### DIFF
--- a/lib/vagrant-libvirt/action/read_state.rb
+++ b/lib/vagrant-libvirt/action/read_state.rb
@@ -27,10 +27,17 @@ module VagrantPlugins
           end
           # Find the machine
           begin
+            # Wait for libvirt to shutdown the domain
+            while libvirt.servers.get(machine.id).state.to_sym == :'shutting-down' do
+              @logger.info('Waiting on the machine to shut down...')
+              sleep 1
+            end
+
             server = libvirt.servers.get(machine.id)
-            if server.nil? || [:'shutting-down', :terminated].include?(server.state.to_sym)
+
+            if server.nil? || server.state.to_sym == :terminated
               # The machine can't be found
-              @logger.info('Machine shutting down or terminated, assuming it got destroyed.')
+              @logger.info('Machine terminated, assuming it got destroyed.')
               machine.id = nil
               return :not_created
             end


### PR DESCRIPTION
I did some testing and investigation of #293 and found out that sometimes we just get the libvirt's domain state too soon and assume that 'shutting-down' state means the domains gotta be removed altogether which is not true since we are also shutting down the domain on `halt` and sometimes it takes libvirt a little longer to do so. With this patch I was doing vagrant up/halt/destroy all night on a multi-machine setup that broke before in half an hour and did not get any issue.

We might find a better way in the future, but so far this works and if you don't have any big objections I am gonna include this patch to my Fedora builds as I can't have users complaining about an issue they even don't know how to recover from.

This should fix #293.