### PR TITLE
Fix trivial bug where graphics_passwd could not be used with spice

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ end
 * `initrd` - To specify the initramfs/initrd to use for the guest. Equivalent to qemu `-initrd`.
 * `random_hostname` - To create a domain name with extra information on the end to prevent hostname conflicts.
 * `cmd_line` - Arguments passed on to the guest kernel initramfs or initrd to use. Equivalent to qemu `-append`.
-* `graphics_type` - Sets the protocol used to expose the guest display.  Defaults to `vnc`.  Possible values are "sdl", "curses", "none", "gtk", or "vnc".
+* `graphics_type` - Sets the protocol used to expose the guest display.  Defaults to `vnc`.  Possible values are "sdl", "curses", "none", "gtk", "vnc" or "spice".
 * `graphics_port` - Sets the port for the display protocol to bind to.  Defaults to 5900.
 * `graphics_ip` - Sets the IP for the display protocol to bind to.  Defaults to "127.0.0.0.1".
 * `graphics_passwd` - Sets the password for the display protocol. Working for vnc and spice. by default working without passsword.

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -287,7 +287,7 @@ module VagrantPlugins
         @graphics_type = 'vnc' if @graphics_type == UNSET_VALUE
         @graphics_autoport = 'yes' if @graphics_port == UNSET_VALUE
         @graphics_autoport = 'no' if @graphics_port != UNSET_VALUE
-        if (@graphics_type != 'vnc' && @graphics_port != 'spice') ||
+        if (@graphics_type != 'vnc' && @graphics_type != 'spice') ||
             @graphics_passwd == UNSET_VALUE
           @graphics_passwd = nil
         end


### PR DESCRIPTION
I double checked the doc and **spice** is a valid graphis_type.
https://libvirt.org/formatdomain.html#elementsGraphics

I couldn't find "curses" and "gtk" listed there though.