### PR TITLE
fix extra disk removal

### DIFF
--- a/lib/vagrant-libvirt/action/destroy_domain.rb
+++ b/lib/vagrant-libvirt/action/destroy_domain.rb
@@ -39,10 +39,10 @@ module VagrantPlugins
             env[:machine].provider_config.disks.each do |disk|
               # shared disks remove only manualy or ???
               next if disk[:allow_existing]
-              diskname = libvirt_domain.name + '-' + disk[:device] + '.' + disk[:type].to_s
+              disk[:path] ||= "#{libvirt_domain.name}-#{disk[:device]}.#{disk[:type]}"
               # diskname is uniq
               libvirt_disk = env[:libvirt_compute].volumes.all.select do |x|
-                x.name == diskname
+                x.name == disk[:path]
               end.first
               libvirt_disk.destroy if libvirt_disk
             end


### PR DESCRIPTION
I have no idea how that `libvirt_domain.name + "-" + disk[:device] + ".raw"` was suposed to work, but the disk gets created using `disk[:path]` so use that for destruction too