### PR TITLE
Fixed wrong target spec in 9p-fs template

### DIFF
--- a/lib/vagrant-libvirt/cap/synced_folder.rb
+++ b/lib/vagrant-libvirt/cap/synced_folder.rb
@@ -43,7 +43,8 @@ module VagrantPlugins
         begin
           # loop through folders
           folders.each do |id, folder_opts|
-            folder_opts.merge!({ :accessmode => "passthrough",
+            folder_opts.merge!({ :target => id,
+								 :accessmode => "passthrough",
                                  :readonly => nil }) { |_k, ov, _nv| ov }
             machine.ui.info "================\nMachine id: #{machine.id}\nShould be mounting folders\n #{id}, opts: #{folder_opts}"
 

--- a/lib/vagrant-libvirt/templates/filesystem.xml.erb
+++ b/lib/vagrant-libvirt/templates/filesystem.xml.erb
@@ -1,7 +1,7 @@
     <filesystem type='mount' accessmode='<%= accessmode %>'>
       <driver type='path' wrpolicy='immediate'/>
       <source dir='<%= hostpath %>'/>
-      <target dir='<%= guestpath %>'/>
+      <target dir='<%= target %>'/>
       <% unless readonly.nil? %>
          <readonly /> 
       <% end %>


### PR DESCRIPTION
When using a id attribute to specify a synced folder the mount inside the guest fails, since the user-defined id will be used as mount_tag by vagrant-libvirt. Unfortunately this mount_tag has never been announced to libvirt/qemu as target via filesystem.xml.erb.

Inside filesystem.xml.erb the target was always the guestpath which is completely ok when no id was specified by the user and vagrant takes care of it.