### PR TITLE
Remove extra StartDomain/WaitTillUp

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -41,9 +41,6 @@ module VagrantPlugins
               b2.use StartDomain
               b2.use WaitTillUp
 
-              b2.use StartDomain
-              b2.use WaitTillUp
-
               b2.use ForwardPorts
 
               b2.use PrepareNFSSettings


### PR DESCRIPTION
Possibly a merge error introduced by 

https://github.com/pradels/vagrant-libvirt/commit/8d4f16a3f8d9e8c7b5fd2c4de8af6f47a1eea64c