### PR TITLE
Add ability to specify the machine architecture via the domain arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ end
 * `keymap` - Set keymap for vm. default: en-us
 * `video_vram` - Used by some graphics card types to vary the amount of RAM dedicated to video.  Defaults to 9216.
 * `machine` - Sets machine type. Equivalent to qemu `-machine`. Use `qemu-system-x86_64 -machine help` to get a list of supported machines.
+* `machine_arch` - Sets machine architecture. This helps libvirt to determine the correct emulator type. Possible values depend on your version of qemu. For possible values, see which emulator executable `qemu-system-*` your system provides. Common examples are `aarch64`, `alpha`, `arm`, `cris`, `i386`, `lm32`, `m68k`, `microblaze`, `microblazeel`, `mips`, `mips64`, `mips64el`, `mipsel`, `moxie`, `or32`, `ppc`, `ppc64`, `ppcemb`, `s390x`, `sh4`, `sh4eb`, `sparc`, `sparc64`, `tricore`, `unicore32`, `x86_64`, `xtensa`, `xtensaeb`.
 
 
 Specific domain settings can be set for each domain separately in multi-VM
@@ -459,4 +460,3 @@ IMPORTANT NOTE: bundle is crucial. You need to use bundled vagrant.
 3. Commit your changes (`git commit -am 'Add some feature'`).
 4. Push to the branch (`git push origin my-new-feature`).
 5. Create new Pull Request.
-

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -34,6 +34,7 @@ module VagrantPlugins
           @cpus = config.cpus.to_i
           @cpu_mode = config.cpu_mode
           @machine_type = config.machine_type
+          @machine_arch = config.machine_arch
           @disk_bus = config.disk_bus
           @nested = config.nested
           @memory_size = config.memory.to_i * 1024

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -56,6 +56,7 @@ module VagrantPlugins
       attr_accessor :cpus
       attr_accessor :cpu_mode
       attr_accessor :machine_type
+      attr_accessor :machine_arch
       attr_accessor :disk_bus
       attr_accessor :nic_model_type
       attr_accessor :nested
@@ -95,6 +96,7 @@ module VagrantPlugins
         @cpus              = UNSET_VALUE
         @cpu_mode          = UNSET_VALUE
         @machine_type      = UNSET_VALUE
+        @machine_arch      = UNSET_VALUE
         @disk_bus          = UNSET_VALUE
         @nic_model_type    = UNSET_VALUE
         @nested            = UNSET_VALUE
@@ -277,6 +279,7 @@ module VagrantPlugins
         @cpus = 1 if @cpus == UNSET_VALUE
         @cpu_mode = 'host-model' if @cpu_mode == UNSET_VALUE
         @machine_type = nil if @machine_type == UNSET_VALUE
+        @machine_arch = nil if @machine_arch == UNSET_VALUE
         @disk_bus = 'virtio' if @disk_bus == UNSET_VALUE
         @nic_model_type = 'virtio' if @nic_model_type == UNSET_VALUE
         @nested = false if @nested == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -14,11 +14,19 @@
   <% end %>
 
   <os>
-  <% if @machine_type %>
-    <type machine='<%= @machine_type %>'>hvm</type>
-  <% else %>
-    <type>hvm</type>
-  <% end %>
+    <% if @machine_type %>
+      <% if @machine_arch %>
+        <type arch='<%= @machine_arch %>' machine='<%= @machine_type %>'>hvm</type>
+      <% else %>
+        <type machine='<%= @machine_type %>'>hvm</type>
+      <% end %>
+    <% else %>
+      <% if @machine_arch %>
+        <type arch='<%= @machine_arch %>'>hvm</type>
+      <% else %>
+        <type>hvm</type>
+      <% end %>
+    <% end %>
     <boot dev='hd'/>
     <kernel><%= @kernel %></kernel>
     <initrd><%= @initrd %></initrd>


### PR DESCRIPTION
This pull request allows the specification of the machine arch via the domain options.
This should, to a degree, resolve #340 as libvirt will probe the emulator by arch if the emulator is not explicitly specified.

Example:
``` 
  config.vm.provider :libvirt do |domain|
    domain.machine_arch = "x86_64"
  end
```

will generate
```
 <os>
   <type arch="x86_64" ... >hvm</type>
   ...
 </os>
 <devices>
   <emulator>/usr/sbin/qemu-system-x86_64</emulator>
   ...
 </devices>
```