### PR TITLE
Don't raise an error when ip address is not found when calling ssh_info

### DIFF
--- a/lib/vagrant-libvirt/action/read_ssh_info.rb
+++ b/lib/vagrant-libvirt/action/read_ssh_info.rb
@@ -20,6 +20,7 @@ module VagrantPlugins
 
         def read_ssh_info(libvirt, machine)
           return nil if machine.id.nil?
+          return nil if machine.state.id != :running
 
           # Find the machine
           domain = libvirt.servers.get(machine.id)
@@ -32,15 +33,23 @@ module VagrantPlugins
 
           # Get IP address from dnsmasq lease file.
           ip_address = nil
-          domain.wait_for(2) {
-            addresses.each_pair do |type, ip|
-              # Multiple leases are separated with a newline, return only
-              # the most recent address
-              ip_address = ip[0].split("\n").first if ip[0] != nil
+          begin
+            domain.wait_for(2) do
+              addresses.each_pair do |type, ip|
+                # Multiple leases are separated with a newline, return only
+                # the most recent address
+                ip_address = ip[0].split("\n").first if ip[0] != nil
+              end
+              ip_address != nil
             end
-            ip_address != nil
-          }
-          raise Errors::NoIpAddressError if not ip_address
+          rescue Fog::Errors::TimeoutError
+            @logger.info("Timeout at waiting for an ip address for machine %s" % machine.name)
+          end
+
+          if not ip_address
+            @logger.info("No lease found for machine %s" % machine.name)
+            return nil
+          end
 
           ssh_info = {
             :host          => ip_address,


### PR DESCRIPTION
Vagrant defines that, when the ssh info is not available, the method should
return nil, instead of raising exception: 
https://github.com/mitchellh/vagrant/blob/v1.7.2/lib/vagrant/plugin/v2/provider.rb#L52-L75

Also, as per 
https://github.com/mitchellh/vagrant/blob/efd1d5e11bfc5a72c7a1d1eae294b4751d841544/plugins/providers/virtualbox/provider.rb#L60
, not getting into waiting for the ssh info when the machine is not running.

The motivation for this patch is the ansible integration issues when raising 
the errors and waiting for the ssh info. See also: 
https://github.com/mitchellh/vagrant/pull/5743