### PR TITLE
Make NFS correctly detect host/guest addresses.

### DIFF
--- a/lib/vagrant-libvirt/action/prepare_nfs_settings.rb
+++ b/lib/vagrant-libvirt/action/prepare_nfs_settings.rb
@@ -19,8 +19,8 @@ module VagrantPlugins
 
           if using_nfs?
             @logger.info("Using NFS, preparing NFS settings by reading host IP and machine IP")
-            env[:nfs_host_ip]    = read_host_ip(env[:machine])
             env[:nfs_machine_ip] = read_machine_ip(env[:machine])
+            env[:nfs_host_ip]    = read_host_ip(env[:nfs_machine_ip])
 
             @logger.info("host IP: #{env[:nfs_host_ip]} machine IP: #{env[:nfs_machine_ip]}")
 
@@ -39,9 +39,9 @@ module VagrantPlugins
         #
         # @param [Machine] machine
         # @return [String]
-        def read_host_ip(machine)
+        def read_host_ip(ip)
           UDPSocket.open do |s|
-            s.connect(machine.ssh_info[:host], 1)
+            s.connect(ip, 1)
             s.addr.last
           end
         end


### PR DESCRIPTION
The logic is that we first gather all usable guest addresses, then
use routing information (through a udp socket) to figure out host
IP for use to connect to guest.