### PR TITLE
Use storage pool to identify correct volume

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -68,9 +68,10 @@ module VagrantPlugins
 
           @os_type = 'hvm'
 
-          # Get path to domain image.
+          # Get path to domain image from the storage pool selected.
           domain_volume = ProviderLibvirt::Util::Collection.find_matching(
-            env[:libvirt_compute].volumes.all, "#{@name}.img")
+            env[:libvirt_compute].volumes.all.select { |x| x.pool_name == @storage_pool_name },
+            "#{@name}.img")
           raise Errors::DomainVolumeExists if domain_volume.nil?
           @domain_volume_path = domain_volume.path
 
@@ -88,7 +89,8 @@ module VagrantPlugins
 
             disk[:absolute_path] = storage_prefix + disk[:path]
 
-            if env[:libvirt_compute].volumes.all.select {|x| x.name == disk[:name] }.empty?
+            if env[:libvirt_compute].volumes.select {
+                |x| x.name == disk[:name] and x.pool_name == @storage_pool_name}.empty?
               # make the disk. equivalent to:
               # qemu-img create -f qcow2 <path> 5g
               begin


### PR DESCRIPTION
Compare storage pool on the found volumes to avoid selecting a disk from
a different and unreachable to the domain storage pool.

Users may move between storage pools by configuring the driver which
will mean that it is possible to find the same image name in multiple
storage pools and incorrectly perform operations based on the one not
associated with the currently specified pool.

When using persistent images to attach to storage this will cause domain
creation to fail since although the image was found in one of the
storage pools, it may not be connected since it does not exist in the
storage pool requested for the VM.