### PR TITLE
Do not remove `.ssh` on package

### DIFF
--- a/lib/vagrant-libvirt/action/package_domain.rb
+++ b/lib/vagrant-libvirt/action/package_domain.rb
@@ -37,7 +37,7 @@ module VagrantPlugins
           `qemu-img rebase -p -b "" #{@tmp_img}`
           # remove hw association with interface
           # working for centos with lvs default disks
-          `virt-sysprep --no-logfile  -a #{@tmp_img} `
+          `virt-sysprep --no-logfile --operations defaults,-ssh-userdir -a #{@tmp_img} `
           Dir.chdir(@tmp_dir)
           img_size = `qemu-img info #{@tmp_img} | grep 'virtual size' | awk '{print $3;}' | tr -d 'G'`.chomp
           File.write(@tmp_dir + '/metadata.json', metadata_content(img_size))


### PR DESCRIPTION
`virt-sysprep` will, by default, remove all `.ssh` directories from all
users' home directories. Since we need to have the default Vagrant
insecure keypair in the `authorized_keys`, this causes problems later
when trying to use the packaged box, as Vagrant is unable to log in.

`virt-sysprep` has the ability to disable options via the `--operations`
argument; the `ssh-userdir` option should be disabled.