### PR TITLE
Support volume size resize configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ end
 * `video_vram` - Used by some graphics card types to vary the amount of RAM dedicated to video.  Defaults to 9216.
 * `machine` - Sets machine type. Equivalent to qemu `-machine`. Use `qemu-system-x86_64 -machine help` to get a list of supported machines.
 * `machine_arch` - Sets machine architecture. This helps libvirt to determine the correct emulator type. Possible values depend on your version of qemu. For possible values, see which emulator executable `qemu-system-*` your system provides. Common examples are `aarch64`, `alpha`, `arm`, `cris`, `i386`, `lm32`, `m68k`, `microblaze`, `microblazeel`, `mips`, `mips64`, `mips64el`, `mipsel`, `moxie`, `or32`, `ppc`, `ppc64`, `ppcemb`, `s390x`, `sh4`, `sh4eb`, `sparc`, `sparc64`, `tricore`, `unicore32`, `x86_64`, `xtensa`, `xtensaeb`.
+* `machine_virtual_size` - Sets the disk size for the machine overriding the default specified in the box. Allows boxes to defined with a minimal size disk by default and to be grown to a larger size at creation time. Will ignore sizes smaller than the size specified by the box metadata. Note that currently there is no support for automatically resizing the filesystem to take advantage of the larger disk.
 * `boot` - Change the boot order and enables the boot menu. Possible options are "hd" or "network". Defaults to "hd" with boot menu disabled.
 
 

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -120,7 +120,7 @@ module VagrantPlugins
           env[:ui].info(" -- Memory:            #{@memory_size / 1024}M")
           env[:ui].info(" -- Base box:          #{env[:machine].box.name}")
           env[:ui].info(" -- Storage pool:      #{@storage_pool_name}")
-          env[:ui].info(" -- Image:             #{@domain_volume_path}")
+          env[:ui].info(" -- Image:             #{@domain_volume_path} (#{env[:box_virtual_size]}G)")
           env[:ui].info(" -- Volume Cache:      #{@domain_volume_cache}")
           env[:ui].info(" -- Kernel:            #{@kernel}")
           env[:ui].info(" -- Initrd:            #{@initrd}")

--- a/lib/vagrant-libvirt/action/create_domain_volume.rb
+++ b/lib/vagrant-libvirt/action/create_domain_volume.rb
@@ -34,8 +34,8 @@ module VagrantPlugins
             env[:libvirt_compute].volumes.all, env[:box_volume_name])
           @backing_file = box_volume.path
 
-          # Virtual size of image. Same as box image size.
-          @capacity = env[:machine].box.metadata['virtual_size'] #G
+          # Virtual size of image. Take value worked out by HandleBoxImage
+          @capacity = env[:box_virtual_size] #G
 
           # Create new volume from xml template. Fog currently doesn't support
           # volume snapshots directly.

--- a/lib/vagrant-libvirt/action/handle_box_image.rb
+++ b/lib/vagrant-libvirt/action/handle_box_image.rb
@@ -37,6 +37,23 @@ module VagrantPlugins
           env[:box_volume_name] = env[:machine].box.name.to_s.dup.gsub("/", "-VAGRANTSLASH-")
           env[:box_volume_name] << "_vagrant_box_image_#{env[:machine].box.version.to_s rescue ''}.img"
 
+          # Override box_virtual_size
+          if config.machine_virtual_size
+            if config.machine_virtual_size < box_virtual_size
+              # Warn that a virtual size less than the box metadata size
+              # is not supported and will be ignored
+              env[:ui].warn I18n.t(
+                'vagrant_libvirt.warnings.ignoring_virtual_size_too_small',
+                requested: config.machine_virtual_size, minimum: box_virtual_size
+              )
+            else
+              env[:ui].info I18n.t('vagrant_libvirt.manual_resize_required')
+              box_virtual_size = config.machine_virtual_size
+            end
+          end
+          # save for use by later actions
+          env[:box_virtual_size] = box_virtual_size
+
           # while inside the synchronize block take care not to call the next
           # action in the chain, as must exit this block first to prevent
           # locking all subsequent actions as well.

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -58,6 +58,7 @@ module VagrantPlugins
       attr_accessor :boot_order
       attr_accessor :machine_type
       attr_accessor :machine_arch
+      attr_accessor :machine_virtual_size
       attr_accessor :disk_bus
       attr_accessor :nic_model_type
       attr_accessor :nested
@@ -98,6 +99,7 @@ module VagrantPlugins
         @cpu_mode          = UNSET_VALUE
         @machine_type      = UNSET_VALUE
         @machine_arch      = UNSET_VALUE
+        @machine_virtual_size = UNSET_VALUE
         @disk_bus          = UNSET_VALUE
         @nic_model_type    = UNSET_VALUE
         @nested            = UNSET_VALUE
@@ -287,6 +289,7 @@ module VagrantPlugins
         @cpu_mode = 'host-model' if @cpu_mode == UNSET_VALUE
         @machine_type = nil if @machine_type == UNSET_VALUE
         @machine_arch = nil if @machine_arch == UNSET_VALUE
+        @machine_virtual_size = nil if @machine_virtual_size == UNSET_VALUE
         @disk_bus = 'virtio' if @disk_bus == UNSET_VALUE
         @nic_model_type = 'virtio' if @nic_model_type == UNSET_VALUE
         @nested = false if @nested == UNSET_VALUE

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -12,6 +12,9 @@ en:
       Checking if volume is available.
     creating_domain: |-
       Creating domain with the following settings...
+    manual_resize_required: |-
+      Created volume larger than box defaults, will require manual resizing of
+      filesystems to utilize.
     uploading_volume: |-
       Uploading base box image as volume into libvirt storage...
     creating_domain_volume: |-
@@ -46,6 +49,11 @@ en:
       Machine is booted and ready for use!
     remove_stale_volume: |-
       Remove stale volume...
+
+    warnings:
+      ignoring_virtual_size_too_small: |-
+        Ignoring requested virtual disk size of '%{requested}' as it is below
+        the minimum box image size of '%{box_virtual_size}'.
 
     errors:
       package_not_supported: Not support package for libvirt. Create box manualy.


### PR DESCRIPTION
Allow control of the volume size to be increased from the box default
virtual_size value so that it is possible to use a box configured with a
minimal initial disk size and create virtual guests with larger disk
sizes.

Warn the user and ignore sizes that are less than the box size, and
inform them that a manual filesystem resize will be needed to take
advantage of the additional available disk space.

fixes: #37