### PR TITLE
set nic adapter limit as a variable. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ end
 * `machine_arch` - Sets machine architecture. This helps libvirt to determine the correct emulator type. Possible values depend on your version of qemu. For possible values, see which emulator executable `qemu-system-*` your system provides. Common examples are `aarch64`, `alpha`, `arm`, `cris`, `i386`, `lm32`, `m68k`, `microblaze`, `microblazeel`, `mips`, `mips64`, `mips64el`, `mipsel`, `moxie`, `or32`, `ppc`, `ppc64`, `ppcemb`, `s390x`, `sh4`, `sh4eb`, `sparc`, `sparc64`, `tricore`, `unicore32`, `x86_64`, `xtensa`, `xtensaeb`.
 * `machine_virtual_size` - Sets the disk size in GB for the machine overriding the default specified in the box. Allows boxes to defined with a minimal size disk by default and to be grown to a larger size at creation time. Will ignore sizes smaller than the size specified by the box metadata. Note that currently there is no support for automatically resizing the filesystem to take advantage of the larger disk.
 * `boot` - Change the boot order and enables the boot menu. Possible options are "hd" or "network". Defaults to "hd" with boot menu disabled.
+* `nic_adapter_count` - Defaults to '8'. Only use case for increasing this count is for VMs that virtualize switches such as Cumulus Linux. Max value for Cumulus Linux VMs is 33.
 
 
 Specific domain settings can be set for each domain separately in multi-VM

--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -19,6 +19,7 @@ module VagrantPlugins
           @management_network_name = env[:machine].provider_config.management_network_name
 	        config = env[:machine].provider_config
 	        @nic_model_type = config.nic_model_type
+          @nic_adapter_count = config.nic_adapter_count
           @app = app
         end
 
@@ -165,7 +166,7 @@ module VagrantPlugins
 
         private
 
-        def find_empty(array, start=0, stop=8)
+        def find_empty(array, start=0, stop=@nic_adapter_count)
           (start..stop).each do |i|
             return i if !array[i]
           end

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -75,6 +75,11 @@ module VagrantPlugins
       attr_accessor :video_vram
       attr_accessor :keymap
 
+      # Sets the max number of NICs that can be created
+      # Default set to 8. Don't change the default unless you know
+      # what are doing
+      attr_accessor :nic_adapter_count
+
       # Storage
       attr_accessor :disks
   	  attr_accessor :cdroms
@@ -116,13 +121,15 @@ module VagrantPlugins
         @video_vram        = UNSET_VALUE
         @keymap            = UNSET_VALUE
 
+        @nic_adapter_count = UNSET_VALUE
+
         # Boot order
         @boot_order = []
         # Storage
         @disks             = []
         @cdroms			       = []
       end
-      
+
       def boot(device)
         @boot_order << device	# append
       end
@@ -309,7 +316,8 @@ module VagrantPlugins
         @video_type = 'cirrus' if @video_type == UNSET_VALUE
         @video_vram = 9216 if @video_vram == UNSET_VALUE
         @keymap = 'en-us' if @keymap == UNSET_VALUE
-        
+        @nic_adapter_count = 8 if @nic_adapter_count == UNSET_VALUE
+
         # Boot order
         @boot_order = [] if @boot_order == UNSET_VALUE
 


### PR DESCRIPTION
Default remains 8 like it was hard coded before. Only use case for changing this is if using
virtualized switch VMs that have support for many interfaces