### PR TITLE
Limit p9 tag to 31 bytes

### DIFF
--- a/lib/vagrant-libvirt/cap/mount_p9.rb
+++ b/lib/vagrant-libvirt/cap/mount_p9.rb
@@ -1,3 +1,4 @@
+require "digest/md5"
 require "vagrant/util/retryable"
 
 module VagrantPlugins
@@ -16,7 +17,7 @@ module VagrantPlugins
             machine.communicate.sudo("mkdir -p #{expanded_guest_path}")
 
             # Mount
-            mount_tag = name.dup
+            mount_tag = Digest::MD5.new.update(name).to_s[0,31]
 
             mount_opts="-o trans=virtio"
             mount_opts += ",access=#{opts[:owner]}" if opts[:owner]


### PR DESCRIPTION
Libvirt p9 file system passthrough requires the tag be less than
31 bytes. Using the mount point as the tag can easily exceed this.

Fixes #323