### PR TITLE
Allow veryisolated networks

### DIFF
--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -63,9 +63,6 @@ module VagrantPlugins
 
               if @options[:ip]
                 handle_ip_option(env)
-              # in vagrant 1.2.3 and later it is not possible to take this branch
-              # because cannot have name without ip
-              # https://github.com/mitchellh/vagrant/commit/cf2f6da4dbcb4f57c9cdb3b94dcd0bba62c5f5fd
               elsif @options[:network_name]
                 handle_network_name_option(env)
               end

--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -116,13 +116,16 @@ module VagrantPlugins
         # @available_networks should be filled before calling this function.
         def handle_ip_option(env)
           return if !@options[:ip]
+          net_address = nil
+          if @options[:forward_mode] != 'veryisolated'
+            net_address = network_address(@options[:ip], @options[:netmask])
+            # Set IP address of network (actually bridge). It will be used as
+            # gateway address for machines connected to this network.
+            net = IPAddr.new(net_address)
+          end
 
-          net_address = network_address(@options[:ip], @options[:netmask])
           @interface_network[:network_address] = net_address
 
-          # Set IP address of network (actually bridge). It will be used as
-          # gateway address for machines connected to this network.
-          net = IPAddr.new(net_address)
           # Default to first address (after network name)
           @interface_network[:ip_address] = @options[:host_ip].nil? ? net.to_range.begin.succ : IPAddr.new(@options[:host_ip])
 

--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -140,6 +140,13 @@ module VagrantPlugins
               break
             end
           end
+          # if network is veryisolated, search by name instead
+          if @options[:libvirt__forward_mode] == "veryisolated"
+            if lookup_network_by_name(@options[:network_name])
+              @interface_network = lookup_network_by_name(@options[:network_name])
+              @logger.debug @interface_network
+            end
+          end
 
           if @interface_network[:created]
             verify_dhcp


### PR DESCRIPTION
With veryisolated networks, there is no ip address assigned thus
matching the network name and ip address fails. This allows the null ip
address to match a named network when that forward_mode is set.