### PR TITLE
Allow read actions to be called by other machines

### DIFF
--- a/lib/vagrant-libvirt/provider.rb
+++ b/lib/vagrant-libvirt/provider.rb
@@ -45,7 +45,7 @@ module VagrantPlugins
         #  :username => "mitchellh",
         #  :private_key_path => "/path/to/my/key"
         #}
-        env = @machine.action('read_ssh_info')
+        env = @machine.action('read_ssh_info', :lock => false)
         env[:machine_ssh_info]
       end
 
@@ -67,7 +67,7 @@ module VagrantPlugins
         # Run a custom action we define called "read_state" which does
         # what it says. It puts the state in the `:machine_state_id`
         # key in the environment.
-        env = @machine.action('read_state')
+        env = @machine.action('read_state', :lock => false)
 
         state_id = env[:machine_state_id]
 


### PR DESCRIPTION
Disable action locks on read actions so that Vagrant may return ssh
configuration information while other actions are being run on the
machine.

Vagrant locks each machine when an action is being performed on it, to
ensure that it cannot be modified by multiple actions at the same time.
However certain read operations such as retrieving the ssh infomation
may be called either by other machines when executing in parallel or if
the user executes 'vagrant ssh <machine>', during a provision step. When
this occurs Vagrant will throw an error telling the user that multiple
actions may not be executed in parallel and they must wait until the
existing action is finished or see if vagrant/ruby must be terminated.

Example issue is that the ansible provisioner builds an inventory file
where for each machine executing it will query the ssh_info of all other
active machines. When run serially, this will work as expected, however
in parallel it will only succeed if all the actions associated with
ssh_info are complete before any machine begins executing ansible
itself.

Fixes #420