### PR TITLE
Really Limit p9 tag to 31 bytes

### DIFF
--- a/lib/vagrant-libvirt/cap/mount_p9.rb
+++ b/lib/vagrant-libvirt/cap/mount_p9.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
             machine.communicate.sudo("mkdir -p #{expanded_guest_path}")
 
             # Mount
-            mount_tag = Digest::MD5.new.update(name).to_s[0,31]
+            mount_tag = Digest::MD5.new.update(opts[:hostpath]).to_s[0,31]
 
             mount_opts="-o trans=virtio"
             mount_opts += ",access=#{opts[:owner]}" if opts[:owner]

--- a/lib/vagrant-libvirt/cap/synced_folder.rb
+++ b/lib/vagrant-libvirt/cap/synced_folder.rb
@@ -1,6 +1,7 @@
 require 'log4r'
 require 'ostruct'
 require 'nokogiri'
+require "digest/md5"
 
 require 'vagrant/util/subprocess'
 require 'vagrant/errors'
@@ -38,7 +39,12 @@ module VagrantPlugins
             folder_opts.merge!({  target: id,
                                   accessmode: 'passthrough',
                                   readonly: nil }) { |_k, ov, _nv| ov }
+
+            mount_tag = Digest::MD5.new.update(folder_opts[:hostpath]).to_s[0,31]
+            folder_opts[:mount_tag] = mount_tag
+            
             machine.ui.info "================\nMachine id: #{machine.id}\nShould be mounting folders\n #{id}, opts: #{folder_opts}"
+            
             xml =  to_xml('filesystem', folder_opts)
             # puts "<<<<< XML:\n #{xml}\n >>>>>"
             @conn.lookup_domain_by_uuid(machine.id).attach_device(xml, 0)

--- a/lib/vagrant-libvirt/templates/filesystem.xml.erb
+++ b/lib/vagrant-libvirt/templates/filesystem.xml.erb
@@ -1,7 +1,7 @@
     <filesystem type='mount' accessmode='<%= accessmode %>'>
       <driver type='path' wrpolicy='immediate'/>
       <source dir='<%= hostpath %>'/>
-      <target dir='<%= target %>'/>
+      <target dir='<%= mount_tag %>'/>
       <% unless readonly.nil? %>
          <readonly /> 
       <% end %>


### PR DESCRIPTION
Libvirt p9 file system passthrough requires the tag be less than
31 bytes. Using the mount point as the tag can easily exceed this.

In KVM passthough the "target" attribuite in the XML is acutally the
mount tag.

Fixed the mounting script to use the same MD5 to mount the right
filesystem

Fixes #323