### PR TITLE
Use per device boot order when boot_order is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ end
 * `machine` - Sets machine type. Equivalent to qemu `-machine`. Use `qemu-system-x86_64 -machine help` to get a list of supported machines.
 * `machine_arch` - Sets machine architecture. This helps libvirt to determine the correct emulator type. Possible values depend on your version of qemu. For possible values, see which emulator executable `qemu-system-*` your system provides. Common examples are `aarch64`, `alpha`, `arm`, `cris`, `i386`, `lm32`, `m68k`, `microblaze`, `microblazeel`, `mips`, `mips64`, `mips64el`, `mipsel`, `moxie`, `or32`, `ppc`, `ppc64`, `ppcemb`, `s390x`, `sh4`, `sh4eb`, `sparc`, `sparc64`, `tricore`, `unicore32`, `x86_64`, `xtensa`, `xtensaeb`.
 * `machine_virtual_size` - Sets the disk size in GB for the machine overriding the default specified in the box. Allows boxes to defined with a minimal size disk by default and to be grown to a larger size at creation time. Will ignore sizes smaller than the size specified by the box metadata. Note that currently there is no support for automatically resizing the filesystem to take advantage of the larger disk.
-* `boot` - Change the boot order and enables the boot menu. Possible options are "hd" or "network". Defaults to "hd" with boot menu disabled.
+* `boot` - Change the boot order and enables the boot menu. Possible options are "hd" or "network". Defaults to "hd" with boot menu disabled. When "network" is set first, *all* NICs will be tried before the first disk is tried.
 * `nic_adapter_count` - Defaults to '8'. Only use case for increasing this count is for VMs that virtualize switches such as Cumulus Linux. Max value for Cumulus Linux VMs is 33.
 
 

--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -20,6 +20,7 @@ module VagrantPlugins
 	        config = env[:machine].provider_config
 	        @nic_model_type = config.nic_model_type
           @nic_adapter_count = config.nic_adapter_count
+          @boot_order = config.boot_order
           @app = app
         end
 

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -28,12 +28,7 @@
       <% end %>
     <% end %>
     <% if @boot_order.count >= 1 %>
-      <% @boot_order.each do |b| %>
-        <boot dev='<%= b %>'/>
-      <% end %> 
       <bootmenu enable='yes'/>
-    <% else %>
-      <boot dev='hd' />
     <% end %>
     <kernel><%= @kernel %></kernel>
     <initrd><%= @initrd %></initrd>
@@ -51,6 +46,11 @@
       <source file='<%= @domain_volume_path %>'/>
       <%# we need to ensure a unique target dev -%>
       <target dev='vda' bus='<%= @disk_bus %>'/>
+      <% if @boot_order[0] == 'hd' %>
+        <boot order='1'/>
+      <% elsif @boot_order.count >= 1 %> 
+        <boot order='9'/>
+      <% end %>
     </disk>
 <%# additional disks -%>
 <% @disks.each do |d| -%>

--- a/lib/vagrant-libvirt/templates/interface.xml.erb
+++ b/lib/vagrant-libvirt/templates/interface.xml.erb
@@ -6,5 +6,10 @@
   <target dev='vnet<%= @iface_number %>'/>
   <alias name='net<%= @iface_number %>'/>
   <model type='<%=@model_type%>'/>
+  <% if @boot_order[0] == 'network' %>
+    <boot order='<%= @iface_number+1 %>'/>
+  <% elsif @boot_order.include?('network') %> 
+    <boot order='<%= @iface_number+2 %>'/>
+  <% end %>
 </interface>
 


### PR DESCRIPTION
This allows for network boot with any of the NICs that are defined instead of
only from the primary NIC.