### PR TITLE
Ensure correct order of logger creation

### DIFF
--- a/lib/vagrant-libvirt.rb
+++ b/lib/vagrant-libvirt.rb
@@ -1,5 +1,4 @@
 require 'pathname'
-require 'vagrant-libvirt/plugin'
 
 module VagrantPlugins
   module ProviderLibvirt
@@ -27,3 +26,6 @@ module VagrantPlugins
     end
   end
 end
+
+# make sure base module class defined before loading plugin
+require 'vagrant-libvirt/plugin'

--- a/lib/vagrant-libvirt/plugin.rb
+++ b/lib/vagrant-libvirt/plugin.rb
@@ -24,10 +24,6 @@ module VagrantPlugins
       end
 
       provider('libvirt', parallel: true) do
-        # Setup logging and i18n
-        setup_logging
-        setup_i18n
-
         require_relative 'provider'
         Provider
       end
@@ -89,6 +85,12 @@ module VagrantPlugins
           logger = nil
         end
       end
+
+      # Setup logging and i18n before any autoloading loads other classes
+      # with logging configured as this prevents inheritance of the log level
+      # from the parent logger.
+      setup_logging
+      setup_i18n
 
     end
   end


### PR DESCRIPTION
Loggers must be defined in the correct heirarchial order to ensure that
child loggers inherit the level defined on the parent logger. Otherwise
need to traverse the entire tree to modify the level.

Fixes  #430