### PR TITLE
Enable travis CI testing of github PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+---
+language: ruby
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y libvirt-dev
+  - gem install bundler --version $BUNDLER_VERSION
+install: bundle _${BUNDLER_VERSION}_ install
+script: bundle _${BUNDLER_VERSION}_ exec rspec --color --format documentation
+notifications:
+  email: false
+rvm:
+  - 2.0.0
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+  matrix:
+    - VAGRANT_VERSION=v1.5.4 BUNDLER_VERSION=1.5.3
+    - VAGRANT_VERSION=v1.6.5 BUNDLER_VERSION=1.6.9
+    - VAGRANT_VERSION=v1.7.0 BUNDLER_VERSION=1.7.9
+    - VAGRANT_VERSION=       BUNDLER_VERSION=1.7.9

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,12 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem 'vagrant', :git => 'https://github.com/mitchellh/vagrant.git'
+  if ENV['VAGRANT_VERSION']
+    gem 'vagrant', :git => 'https://github.com/mitchellh/vagrant.git',
+      tag: ENV['VAGRANT_VERSION']
+  else
+    gem 'vagrant', :git => 'https://github.com/mitchellh/vagrant.git'
+  end
   gem 'pry'
 end
 


### PR DESCRIPTION
Add travis CI and support testing against a matrix of vagrant versions.

Initial framework to enable easier checking.