### PR TITLE
Added ability to specify inputs for the VM via the Vagrantfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Vagrant.configure("2") do |config|
     # libvirt.input :type => "mouse", :bus => "ps2"
 
     # very useful when having mouse issues when viewing VM via VNC
-	libvirt.input :type => "tablet", :bus => "usb"
+    libvirt.input :type => "tablet", :bus => "usb"
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -333,6 +333,26 @@ Vagrant.configure("2") do |config|
 end
 ```
 
+## Input
+
+You can multiple inputs to the VM via `libvirt.input`. Available options are
+listed below. Note that both options are required:
+
+* `type` - The type of the input
+* `bus` - The bust of the input
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.provider :libvirt do |libvirt|
+    # this is the default
+    # libvirt.input :type => "mouse", :bus => "ps2"
+
+    # very useful when having mouse issues when viewing VM via VNC
+	libvirt.input :type => "tablet", :bus => "usb"
+  end
+end
+```
+
 ## SSH Access To VM
 
 vagrant-libvirt supports vagrant's [standard ssh settings](https://docs.vagrantup.com/v2/vagrantfile/ssh_settings.html).

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ end
 
 ## Input
 
-You can multiple inputs to the VM via `libvirt.input`. Available options are
+You can specify multiple inputs to the VM via `libvirt.input`. Available options are
 listed below. Note that both options are required:
 
 * `type` - The type of the input

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -58,6 +58,9 @@ module VagrantPlugins
           @disks = config.disks
           @cdroms = config.cdroms
 
+		      # Input
+          @inputs = config.inputs
+
           config = env[:machine].provider_config
           @domain_type = config.driver
 
@@ -132,6 +135,9 @@ module VagrantPlugins
           end
           @cdroms.each do |cdrom|
             env[:ui].info(" -- CDROM(#{cdrom[:dev]}):        #{cdrom[:path]}")
+          end
+          @inputs.each do |input|
+            env[:ui].info(" -- INPUT(type=#{input[:type]}, bus=#{input[:bus]})")
           end
           env[:ui].info(" -- Command line : #{@cmd_line}")
 

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -76,6 +76,9 @@ module VagrantPlugins
       attr_accessor :disks
   	  attr_accessor :cdroms
 
+	  # Inputs
+	  attr_accessor :inputs
+
       def initialize
         @uri               = UNSET_VALUE
         @driver            = UNSET_VALUE
@@ -113,7 +116,10 @@ module VagrantPlugins
 
         # Storage
         @disks             = []
-        @cdroms			       = []
+        @cdroms			   = []
+
+        # Inputs
+        @inputs            = UNSET_VALUE
       end
 
       def _get_device(disks)
@@ -145,6 +151,21 @@ module VagrantPlugins
 
         # is it better to raise our own error, or let libvirt cause the exception?
         raise "Only four cdroms may be attached at a time"
+      end
+
+      def input(options={})
+        if options[:type] == nil or options[:bus] == nil:
+          raise "Input type AND bus must be specified"
+        end
+
+        if @inputs == UNSET_VALUE
+          @inputs = []
+        end
+
+        @inputs.push({
+          :type => options[:type],
+          :bus => options[:bus]
+        })
       end
 
       # NOTE: this will run twice for each time it's needed- keep it idempotent
@@ -297,6 +318,7 @@ module VagrantPlugins
         # Storage
         @disks = [] if @disks == UNSET_VALUE
         @cdroms = [] if @cdroms == UNSET_VALUE
+        @inputs = [{:type => "mouse", :bus => "ps2"}] if @inputs == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -172,7 +172,7 @@ module VagrantPlugins
       end
 
       def input(options={})
-        if options[:type] == nil or options[:bus] == nil:
+        if options[:type] == nil or options[:bus] == nil
           raise "Input type AND bus must be specified"
         end
 

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -63,7 +63,11 @@
     <console type='pty'>
       <target port='0'/>
     </console>
-    <input type='mouse' bus='ps2'/>
+
+	<% @inputs.each do |input| %>
+		<input type='<%= input[:type] %>' bus='<%= input[:bus] %>'/>
+	<% end %>
+
     <%# Video device -%>
     <graphics type='<%= @graphics_type %>' port='<%= @graphics_port %>' autoport='<%= @graphics_autoport %>' listen='<%= @graphics_ip %>' keymap='<%= @keymap %>' <%= @graphics_passwd%> />
       <video>

--- a/spec/support/environment_helper.rb
+++ b/spec/support/environment_helper.rb
@@ -19,7 +19,7 @@ class EnvironmentHelper
     1024
   end
 
-  %w(cpus cpu_mode boot_order machine_type disk_bus nested volume_cache kernel cmd_line initrd graphics_type graphics_autoport graphics_port graphics_ip graphics_passwd video_type video_vram keymap storage_pool_name disks cdroms driver).each do |name|
+  %w(cpus cpu_mode boot_order machine_type disk_bus nested volume_cache kernel cmd_line initrd graphics_type graphics_autoport graphics_port graphics_ip graphics_passwd video_type video_vram keymap storage_pool_name disks cdroms driver inputs).each do |name|
     define_method(name.to_sym) do
       nil
     end


### PR DESCRIPTION
Instead of a hard-coded

```xml
<input type="mouse" bus="ps2"/>
```

The user can now generate other types of inputs with

```ruby
libvirt.input :type => "tablet", :bus => "usb"
```

resulting in domain xml

```xml
<input type="tablet" bus="usb"/>
```