### PR TITLE
UDP/TCP/Mcast tunnel support for point-2-point VM connections

### DIFF
--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
             configured_networks(env, @logger).each do |options|
               # Only need to create private networks
               next if options[:iface_type] != :private_network or
-                options.fetch(:tcp_tunnel_type, nil)
+                options.fetch(:tunnel_type, nil)
               @logger.debug "Searching for network with options #{options}"
 
               # should fix other methods so this doesn't have to be instance var
@@ -133,7 +133,7 @@ module VagrantPlugins
             # Set IP address of network (actually bridge). It will be used as
             # gateway address for machines connected to this network.
             net = IPAddr.new(net_address)
-            
+
             # Default to first address (after network name)
             @interface_network[:ip_address] = @options[:host_ip].nil? ? \
               net.to_range.begin.succ : \
@@ -158,7 +158,7 @@ module VagrantPlugins
           if @interface_network[:created]
             verify_dhcp
           end
-  
+
           if @options[:network_name]
             @logger.debug "Checking that network name does not clash with ip"
             if @interface_network[:created]
@@ -177,13 +177,13 @@ module VagrantPlugins
                       ip_address:   @options[:ip],
                       network_name: @options[:network_name]
               end
-  
+
               # Network with 'name' doesn't exist. Set it as name for new
               # network.
               @interface_network[:name] = @options[:network_name]
             end
           end
-  
+
           # Do we need to create new network?
           if !@interface_network[:created]
 
@@ -235,7 +235,7 @@ module VagrantPlugins
           @interface_network = network if network
 
           # if this interface has a network address, something's wrong.
-          if @interface_network[:network_address] 
+          if @interface_network[:network_address]
             raise Errors::NetworkNotAvailableError,
                   network_name: @options[:network_name]
           end

--- a/lib/vagrant-libvirt/errors.rb
+++ b/lib/vagrant-libvirt/errors.rb
@@ -106,8 +106,8 @@ module VagrantPlugins
         error_key(:activate_network_error)
       end
 
-      class TcpTunnelPortNotDefined < VagrantLibvirtError
-        error_key(:tcp_tunnel_port_not_defined)
+      class TunnelPortNotDefined < VagrantLibvirtError
+        error_key(:tunnel_port_not_defined)
       end
 
       # Other exceptions

--- a/lib/vagrant-libvirt/templates/tcp_tunnel_interface.xml.erb
+++ b/lib/vagrant-libvirt/templates/tcp_tunnel_interface.xml.erb
@@ -1,7 +1,0 @@
-<interface type='<%= @type %>'>
-  <% if @mac %>
-  <mac address='<%= @mac %>'/>
-  <% end %>
-  <source address='<%=@tcp_tunnel_ip%>' port='<%= @tcp_tunnel_port %>'/>
-  <model type='<%=@model_type%>'/>
-</interface>

--- a/lib/vagrant-libvirt/templates/tunnel_interface.xml.erb
+++ b/lib/vagrant-libvirt/templates/tunnel_interface.xml.erb
@@ -1,0 +1,11 @@
+<interface type='<%= @type %>'>
+  <% if @mac %>
+  <mac address='<%= @mac %>'/>
+  <% end %>
+  <source address='<%=@tunnel_ip%>' port='<%= @tunnel_port %>'>
+  <% if @type == 'udp' %>
+    <local address='<%=@udp_tunnel_local_ip%>' port='<%=@udp_tunnel_local_port%>' />
+  <% end %>
+  </source>
+  <model type='<%=@model_type%>'/>
+</interface>

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -135,8 +135,8 @@ en:
         Error while removing network %{network_name}. %{error_message}.
       delete_snapshot_error: |-
         Error while deleting snapshot: %{error_message}.
-      tcp_tunnel_port_not_defined: |-
-        TCP tunnel port not defined.
+      tunnel_port_not_defined: |-
+         tunnel UDP or TCP port not defined.
 
     states:
       paused: |-


### PR DESCRIPTION
Previously #413 introduced TCP tunnel support. This patch expands that feature to  supported tunneling types in QEMU. UDP unicast, TCP and Multicast.

## Topology
```
+---------------+                 +-------------------+
|               |                 |                   |
|               |                 |                   |
|    VM1        |eth1       eth1  |       VM2         |
|               +-----------------+                   |
|               |                 |                   |
|               |                 |                   |
|               |                 |                   |
+---------------+                 +-------------------+

```
## TCP tunnel support config. 

### VM1 (eth1)

#### Vagrant config
```
# VM1(eth1) === VM2(eth1)
    node.vm.network :private_network,
      :libvirt__tunnel_type => 'server',
      :libvirt__tunnel_ip => '127.0.0.1', # default
      :libvirt__tunnel_port => '9999',
```
#### Subsequent Libvirt Config
```
<devices>
    <interface type='server'>
      <source address='127.0.0.1' port='9999'/>
    </interface>
```
### VM2 (eth1)
```

#### Vagrant Config
# VM2(eth1) === VM1(eth1)
    node.vm.network :private_network,
      :libvirt__tunnel_type => 'client',
      :libvirt__tunnel_ip => '127.0.0.1', #default
      :libvirt__tunnel_port => '9999',
```

#### Subsequent Libvirt Config
```
<devices>
    <interface type='client'>
      <source address='127.0.0.1' port='9999'/>
    </interface>
```


## Mcast tunnel support config

### VM1 (eth1)

#### Vagrant config
```
# VM1(eth1) === VM2(eth1)
    node.vm.network :private_network,
      :libvirt__tunnel_type => 'mcast',
      :libvirt__tunnel_ip => '239.255.1.2',
      :libvirt__tunnel_port => '9999',
```
#### Subsequent Libvirt Config
```
<devices>
    <interface type='mcast'>
      <source address='239.255.1.2' port='9999'/>
    </interface>
```
### VM2 (eth1)
```
#### Vagrant Config
# VM2(eth1) === VM1(eth1)
    node.vm.network :private_network,
      :libvirt__tunnel_type => 'mcast',
      :libvirt__tunnel_ip => '239.255.1.2',
      :libvirt__tunnel_port => '9999',
```

### Subsequent Libvirt Config
```
<devices>
    <interface type='mcast'>
      <source address='239.255.1.2' port='9999'/>
    </interface>
```

## UDP tunnel support (requires libvirt 1.2.20)
[libvirt patch just commited](http://libvirt.org/git/?p=libvirt.git;a=commit;h=5c668a78d85b0d71e6ac8e23f2c605058b44df65). Will be in libvirt 1.2.20.

This is actually the most stable way to do point to point VM connections. This is what [GNS3 uses](http://forum.gns3.net/topic3224-40.html).

To get to use this libvirt udp unicast backend patch today, I created a [PPA for Ubuntu 14.04](https://launchpad.net/~linuxsimba/+archive/ubuntu/libvirt-udp-tunnel)

### VM1 (eth1)

#### Vagrant config
```
# VM1(eth1) === VM2(eth1)
    node.vm.network :private_network,
      :libvirt__tunnel_type => 'udp',
      :libvirt__tunnel_ip => '127.0.0.1',  # default
      :libvirt__tunnel_local_ip => '127.0.0.1', # default
      :libvirt__tunnel_local_port => '8888',
      :libvirt__tunnel_port => '9999',
```
#### Subsequent Libvirt Config
```
<devices>
    <interface type='udp'>
      <source address='127.0.0.1' port='9999'>
          <local address='127.0.0.1' port='8888'/>
      </source>
    </interface>
```
### VM2(eth1)

#### Vagrant config
```
# VM1(eth1) === VM2(eth1)
    node.vm.network :private_network,
      :libvirt__tunnel_type => 'udp',
      :libvirt__tunnel_ip => '127.0.0.1',  # default
      :libvirt__tunnel_local_ip => '127.0.0.1', # default
      :libvirt__tunnel_local_port => '9999',
      :libvirt__tunnel_port => '8888',
```
#### Subsequent Libvirt Config
```
<devices>
    <interface type='udp'>
      <source address='127.0.0.1' port='8888'>
          <local address='127.0.0.1' port='9999'/>
      </source>
    </interface>
```
