### PR TITLE
Bump version to 0.0.31-dev

### DIFF
--- a/lib/vagrant-libvirt/version.rb
+++ b/lib/vagrant-libvirt/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module ProviderLibvirt
-    VERSION = '0.0.30'
+    VERSION = '0.0.31-dev'
   end
 end


### PR DESCRIPTION
This allows to differentiate between packaged and development versions
of vagrant-libvirt in `vagrant plugin list`.