### PR TITLE
Fix uninitialized constant DestroyNetworkError

### DIFF
--- a/lib/vagrant-libvirt/action/destroy_networks.rb
+++ b/lib/vagrant-libvirt/action/destroy_networks.rb
@@ -66,7 +66,7 @@ module VagrantPlugins
               libvirt_network.undefine
               @logger.info "Undefined it"
             rescue => e
-              raise Error::DestroyNetworkError,
+              raise Errors::DestroyNetworkError,
                 network_name: libvirt_network.name,
                 error_message: e.message
             end


### PR DESCRIPTION
This was caused by a typo in the class name.