### PR TITLE
Accept both symbol and string for network type

### DIFF
--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -63,7 +63,7 @@ module VagrantPlugins
 
               if @options[:ip]
                 handle_ip_option(env)
-              elsif @options[:type] == :dhcp
+              elsif @options[:type].to_s == 'dhcp'
                 handle_dhcp_private_network(env)
               elsif @options[:network_name]
                 handle_network_name_option(env)

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -60,7 +60,7 @@ module VagrantPlugins
               forward_mode: 'nat',
             }.merge(options)
 
-            if options[:type] == :dhcp && options[:ip].nil?
+            if options[:type].to_s == 'dhcp' && options[:ip].nil?
               options[:network_name] = "vagrant-private-dhcp"
             end
 


### PR DESCRIPTION
Previously, following Vagrant documentation to setup private DHCP
network failed with:

  config.vm.network "private_network", type: "dhcp"

Now libvirt provider accepts both "dhcp" and :dhcp