### PR TITLE
Issue with emulated CPU types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ end
 * `memory` - Amount of memory in MBytes. Defaults to 512 if not set.
 * `cpus` - Number of virtual cpus. Defaults to 1 if not set.
 * `nested` - [Enable nested virtualization](https://github.com/torvalds/linux/blob/master/Documentation/virtual/kvm/nested-vmx.txt). Default is false.
-* `cpu_mode` - What cpu mode to use for nested virtualization. Defaults to 'host-model' if not set.
+* `cpu_mode` - [What cpu type to emulate](https://libvirt.org/formatdomain.html#elementsCPU). Defaults to 'host-model' if not set. Allowed values: host-model, host-passthrough.
 * `loader` - Sets path to custom UEFI loader.
 * `volume_cache` - Controls the cache mechanism. Possible values are "default", "none", "writethrough", "writeback", "directsync" and "unsafe". [See driver->cache in libvirt documentation](http://libvirt.org/formatdomain.html#elementsDisks).
 * `kernel` - To launch the guest with a kernel residing on host filesystems. Equivalent to qemu `-kernel`.

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -3,15 +3,17 @@
   <memory><%= @memory_size %></memory>
   <vcpu><%= @cpus %></vcpu>
 
-  <% if @nested %>
-    <cpu mode='<%= @cpu_mode %>'>
-      <% if @cpu_mode != 'host-passthrough' %>
-        <model fallback='allow'>qemu64</model>
+
+  <cpu mode='<%= @cpu_mode %>'>
+    <% if @cpu_mode != 'host-passthrough' %>
+      <model fallback='allow'>qemu64</model>
+      <% if @nested %>
         <feature policy='optional' name='vmx'/>
         <feature policy='optional' name='svm'/>
       <% end %>
-    </cpu>
-  <% end %>
+    <% end %>
+  </cpu>
+
 
   <os>
     <% if @machine_type %>
@@ -79,9 +81,9 @@
       <target port='0'/>
     </console>
 
-	<% @inputs.each do |input| %>
-		<input type='<%= input[:type] %>' bus='<%= input[:bus] %>'/>
-	<% end %>
+<% @inputs.each do |input| %>
+    <input type='<%= input[:type] %>' bus='<%= input[:bus] %>'/>
+<% end %>
 
     <%# Video device -%>
     <graphics type='<%= @graphics_type %>' port='<%= @graphics_port %>' autoport='<%= @graphics_autoport %>' listen='<%= @graphics_ip %>' keymap='<%= @keymap %>' <%= @graphics_passwd%> />


### PR DESCRIPTION
For better VM performance CPU type should be set not to qemu64, but to
the host cpu type. 
For example see the difference (uppercased are added on my VM host when using this patch)

flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov
pat pse36 clflush mmx fxsr sse sse2 ss syscall nx rdtscp lm constant_tsc
rep_good nopl eagerfpu pni pclmulqdq vmx ssse3 cx16 pcid sse4_1 sse4_2
x2apic popcnt tsc_deadline_timer aes xsave avx hypervisor lahf_lm
tpr_shadow vnmi flexpriority ept xsaveopt

Added extensions when emulating host cpu model (on my VM host): 
flags		: fpu VME de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov
PAT pse36 clflush mmx fxsr sse sse2 SS syscall nx RDTSCP lm CONSTANT_TSC
rep_good nopl EAGERFPU pni PCLMULQDQ vmx **SSSE3** cx16 PCID **SSE4_1** **SSE4_2**
x2apic popcnt TSC_DEADLINE_TIMER **AES** XSAVE **AVX** hypervisor lahf_lm
tpr_shadow vnmi flexpriority ept XSAVEOPT

Nested virtualization requires VMX/SVM capabilities, which are still
being added when domain.nested is set to true. 

Using the current default value for cpu_mode everyone will benefit from
better VMs performance.

Signed-off-by: Max Kutsevol <max@kutsevol.com>