### PR TITLE
If the disk size is specified as a decimal number the generated metad…

### DIFF
--- a/tools/create_box.sh
+++ b/tools/create_box.sh
@@ -81,6 +81,9 @@ fi
 
 cd "$TMP_DIR"
 
+#Using the awk int function here to truncate the virtual image size to an
+#integer since the fog-libvirt library does not seem to properly handle
+#floating point.
 IMG_SIZE=$(qemu-img info "$TMP_IMG" | awk '/virtual size/{print int($3);}' | tr -d 'G')
 
 cat > metadata.json <<EOF

--- a/tools/create_box.sh
+++ b/tools/create_box.sh
@@ -81,8 +81,7 @@ fi
 
 cd "$TMP_DIR"
 
-IMG_SIZE=$(qemu-img info "$TMP_IMG" | grep 'virtual size' | awk '{print int($3);}' | tr -d 'G')
-echo "IMAGE SIZE ====> ${IMG_SIZE}"
+IMG_SIZE=$(qemu-img info "$TMP_IMG" | awk '/virtual size/{print int($3);}' | tr -d 'G')
 
 cat > metadata.json <<EOF
 {

--- a/tools/create_box.sh
+++ b/tools/create_box.sh
@@ -81,7 +81,8 @@ fi
 
 cd "$TMP_DIR"
 
-IMG_SIZE=$(qemu-img info "$TMP_IMG" | grep 'virtual size' | awk '{print $3;}' | tr -d 'G')
+IMG_SIZE=$(qemu-img info "$TMP_IMG" | grep 'virtual size' | awk '{print int($3);}' | tr -d 'G')
+echo "IMAGE SIZE ====> ${IMG_SIZE}"
 
 cat > metadata.json <<EOF
 {


### PR DESCRIPTION
…ata.json file is invalid resulting in a broken vagrant box.  Wrapped this in the awk int() function to only print the integer part of the disk size.