### PR TITLE
Use env[:machine].config.vm.box variable, not .box

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -23,7 +23,7 @@ module VagrantPlugins
             # Create VM if not yet created.
             if !env[:result]
               b2.use SetNameOfDomain
-              if !env[:machine].box
+              if !env[:machine].config.vm.box
                 b2.use CreateDomain
                 b2.use CreateNetworks
                 b2.use CreateNetworkInterfaces
@@ -77,7 +77,7 @@ module VagrantPlugins
                 next
               end
 
-              if !env[:machine].box
+              if !env[:machine].config.vm.box
                 # With no box, we just care about network creation and starting it
                 b3.use CreateNetworks
                 b3.use SetBootOrder
@@ -171,7 +171,7 @@ module VagrantPlugins
             if !env[:result]
               # Try to remove stale volumes anyway
               b2.use SetNameOfDomain
-              if env[:machine].box
+              if env[:machine].config.vm.box
                 b2.use RemoveStaleVolume
               end
               if !env[:result]

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -75,7 +75,7 @@ module VagrantPlugins
           @os_type = 'hvm'
 
           # Get path to domain image from the storage pool selected if we have a box.
-          if env[:machine].box
+          if env[:machine].config.vm.box
             actual_volumes =
               env[:machine].provider.driver.connection.volumes.all.select do |x|
                 x.pool_name == @storage_pool_name
@@ -89,7 +89,7 @@ module VagrantPlugins
           # If we have a box, take the path from the domain volume and set our storage_prefix.
           # If not, we dump the storage pool xml to get its defined path.
           # the default storage prefix is typically: /var/lib/libvirt/images/
-          if env[:machine].box
+          if env[:machine].config.vm.box
             storage_prefix = File.dirname(@domain_volume_path) + '/'        # steal
           else
             storage_pool = env[:machine].provider.driver.connection.client.lookup_storage_pool_by_name(@storage_pool_name)
@@ -142,7 +142,7 @@ module VagrantPlugins
           env[:ui].info(" -- Memory:            #{@memory_size / 1024}M")
           env[:ui].info(" -- Management MAC:    #{@management_network_mac}")
           env[:ui].info(" -- Loader:            #{@loader}")
-          if env[:machine].box
+          if env[:machine].config.vm.box
             env[:ui].info(" -- Base box:          #{env[:machine].box.name}")
           end
           env[:ui].info(" -- Storage pool:      #{@storage_pool_name}")

--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -138,7 +138,7 @@ module VagrantPlugins
           @app.call(env)
 
 
-          if env[:machine].box
+          if env[:machine].config.vm.box
             # Configure interfaces that user requested. Machine should be up and
             # running now.
             networks_to_configure = []


### PR DESCRIPTION
In some cases env[:machine].box is 'nil' when a box is
not already locally present. Combined with the box_optional
flag this causes the box definition in the Vagrantfile to be
ignored completely, yielding unexpected results. All references
are changed to ensure it does not cause other issues.