### PR TITLE
Fix regression with additional disks + additional disk reload support #418

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ welcome and can help a lot :-)
   - [Public Network Options](#public-network-options)
   - [Management Network](#management-network)
 - [Additional Disks](#additional-disks)
+  	- [Reload behavior](#reload-behavior-1)
 - [CDROMs](#cdroms)
 - [Input](#input)
 - [No box and PXE boot](#no-box-and-pxe-boot)
@@ -454,6 +455,12 @@ Vagrant.configure("2") do |config|
   end
 end
 ```
+
+### Reload behavior
+
+On vagrant reload the following additional disk attributes are updated in defined domain:
+
+* `bus` - Updated. Uses `device` as a search marker. It is not required to define `device`, but it's recommended. If `device` is defined then the order of addtitional disk definition becomes irrelevant.
 
 ## CDROMs
 

--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -33,12 +33,25 @@ module VagrantPlugins
               xml_descr = REXML::Document.new descr
               descr_changed = false
 
+              # additional disk bus
+              config.disks.each {|disk|
+                device = disk[:device]
+                bus = disk[:bus]
+                REXML::XPath.each(xml_descr,'/domain/devices/disk[@device="disk"]/target[@dev="'+device+'"]') {|disk_target|
+                  if disk_target.attributes['bus'] != bus
+                    descr_changed = true
+                    disk_target.attributes['bus'] = bus
+                    disk_target.parent.delete_element("#{disk_target.parent.xpath}/address")
+                  end
+                }
+              }
+
               # disk_bus
-              REXML::XPath.each(xml_descr,'/domain/devices/disk[@device="disk"]/target') {|disk_target|
+              REXML::XPath.each(xml_descr,'/domain/devices/disk[@device="disk"]/target[@dev="vda"]') {|disk_target|
                 if disk_target.attributes['bus'] != config.disk_bus
                   descr_changed = true
                   disk_target.attributes['bus'] = config.disk_bus
-                  disk_target.parent.delete_element('//address')
+                  disk_target.parent.delete_element("#{disk_target.parent.xpath}/address")
                 end
               }
 


### PR DESCRIPTION
* Fixed the regression when using additional disks. Now disk_bus setting
applies only to the main disk.
* Added ability to change additional disk bus on reload. Updated readme.