### PR TITLE
Update forward_ports.rb to fix spaces in private key path

### DIFF
--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -98,7 +98,7 @@ module VagrantPlugins
             PasswordAuthentication=no
             ForwardX11=#{ssh_info[:forward_x11] ? 'yes' : 'no'}
           ) + ssh_info[:private_key_path].map do |pk|
-              "IdentityFile=#{pk}"
+              "IdentityFile='\"#{pk}\"'"
             end).map { |s| s.prepend('-o ') }.join(' ')
 
           options += " -o ProxyCommand=\"#{ssh_info[:proxy_command]}\"" if machine.provider_config.connect_via_ssh


### PR DESCRIPTION
When the path to the Vagrant environment contains spaces, the IdentityFile argument to SSH does not get parsed correctly.  The result is that the command fails and no ports are forwarded to the host.  Log Output: command-line line 0: garbage at end of line;

This update places a double quote around the private key path with another pair of single quotes outside of it.  With single or double quotes alone, the command fails.  Combining the double quotes embedded in single quotes results in SSH parsing the argument correctly and the ports are forwarded properly.