### PR TITLE
Option to disable p9 automounting at boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,12 @@ it an setting the type, e.g.
 
     config.vm.synced_folder './', '/vagrant', type: '9p', disabled: false, accessmode: "squash", owner: "vagrant"
 
+    or
+
+    config.vm.synced_folder './', '/vagrant', type: '9p', disabled: false, accessmode: "mapped", mount: false
+
+For 9p shares, a `mount: false` option allows to define synced folders without mounting them at boot.
+
 **SECURITY NOTE:** for remote libvirt, nfs synced folders requires a bridged public network interface and you must connect to libvirt via ssh.
 
 

--- a/lib/vagrant-libvirt/cap/synced_folder.rb
+++ b/lib/vagrant-libvirt/cap/synced_folder.rb
@@ -38,6 +38,7 @@ module VagrantPlugins
           folders.each do |id, folder_opts|
             folder_opts.merge!({  target: id,
                                   accessmode: 'passthrough',
+                                  mount: true,
                                   readonly: nil }) { |_k, ov, _nv| ov }
 
             mount_tag = Digest::MD5.new.update(folder_opts[:hostpath]).to_s[0,31]
@@ -63,7 +64,7 @@ module VagrantPlugins
         # Only mount folders that have a guest path specified.
         mount_folders = {}
         folders.each do |id, opts|
-          if opts[:guestpath] && ! opts[:guestpath].empty?
+          if opts[:mount] && opts[:guestpath] && ! opts[:guestpath].empty?
             mount_folders[id] = opts.dup
             # merge common options if not given
             mount_folders[id].merge!(version: '9p2000.L') { |_k, ov, _nv| ov }

--- a/lib/vagrant-libvirt/cap/synced_folder.rb
+++ b/lib/vagrant-libvirt/cap/synced_folder.rb
@@ -63,9 +63,11 @@ module VagrantPlugins
         # Only mount folders that have a guest path specified.
         mount_folders = {}
         folders.each do |id, opts|
-          mount_folders[id] = opts.dup if opts[:guestpath]
-          # merge common options if not given
-          mount_folders[id].merge!(version: '9p2000.L') { |_k, ov, _nv| ov }
+          if opts[:guestpath] && ! opts[:guestpath].empty?
+            mount_folders[id] = opts.dup
+            # merge common options if not given
+            mount_folders[id].merge!(version: '9p2000.L') { |_k, ov, _nv| ov }
+          end
         end
         # Mount the actual folder
         machine.guest.capability(


### PR DESCRIPTION
Hello,
I've been writing a Vagrantfile where I define some p9 synced_folders which I'd like not to mount at boot, because I need to do machine provisioning first.
I see that there's a long-going issue about this on https://github.com/mitchellh/vagrant/issues/936 . In short, one of the suggested workarounds is to omit the guest path.

This does not work as expected:
```ruby
config.vm.synced_folder "/mnt/warehouse/test1", id: "test1", type: "9p", accessmode: "mapped"
```
and fails with a "shared folder guest path must be absolute" error.

On the other hand, using nil or an empty string as guest path almost does the trick:
```ruby
config.vm.synced_folder "/mnt/warehouse/test1", nil, id: "test1", type: "9p", accessmode: "mapped"
```
but fails with a printf error (guestpath appears to be always converted to empty string from nil and added to the list of shares to be mounted). To fix this I made the first commit which also checks for emptyness of the guest path and eventually skips automount for it.

This works if there is only one share, however I have two and found another issue:
```ruby
config.vm.synced_folder "/mnt/warehouse/test1", nil, id: "test1", type: "9p", accessmode: "mapped"
config.vm.synced_folder "/mnt/warehouse/test2", nil, id: "test2", type: "9p", accessmode: "mapped"
```
When I do a vagrant up, only the second folder is taken into consideration. The reason for this is most likely that either vagrant or vagrant-libvirt is using guestpath to decide which folders to manage and since the guestpath is the same (nil), it only sees the second one.

To fix this, I made a second commit where I added a mount parameter which can be set to false, so now I can have:
```ruby
config.vm.synced_folder "/mnt/warehouse/test1", "/guestdir/test1", id: "test1", type: "9p", accessmode: "mapped", mount: false
config.vm.synced_folder "/mnt/warehouse/test2", "/guestdir/test2", id: "test2", type: "9p", accessmode: "mapped", mount: false
```
which is imho better and cleaner, allowing me to avoid hacks such as not specifying the guest path and to decide which folders I want to be mounted at boot.

Opening a pull request for your consideration.