### PR TITLE
interfaces: allow user to specify an interface name

### DIFF
--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -69,6 +69,7 @@ module VagrantPlugins
             @network_name = iface_configuration[:network_name]
             @mac = iface_configuration.fetch(:mac, false)
             @model_type = iface_configuration.fetch(:model_type, @nic_model_type)
+	    @device_name = iface_configuration.fetch(:iface_name, false)
             template_name = 'interface'
             # Configuration for public interfaces which use the macvtap driver
             if iface_configuration[:iface_type] == :public_network

--- a/lib/vagrant-libvirt/templates/interface.xml.erb
+++ b/lib/vagrant-libvirt/templates/interface.xml.erb
@@ -3,7 +3,11 @@
 	<% if @mac %>
   	<mac address='<%= @mac %>'/>
 	<% end %>
-  <target dev='vnet<%= @iface_number %>'/>
+	<% if @device_name %>
+	<target dev='<%= @device_name %>'/>
+	<% else %>
+	<target dev='vnet<%= @iface_number %>'/>
+	<% end %>
   <alias name='net<%= @iface_number %>'/>
   <model type='<%=@model_type%>'/>
 </interface>

--- a/lib/vagrant-libvirt/templates/tunnel_interface.xml.erb
+++ b/lib/vagrant-libvirt/templates/tunnel_interface.xml.erb
@@ -7,5 +7,11 @@
     <local address='<%=@udp_tunnel_local_ip%>' port='<%=@udp_tunnel_local_port%>' />
   <% end %>
   </source>
+  <% if @device_name %>
+    <target dev='<%= @device_name %>'/>
+  <% else %>
+    <target dev='tnet<%= @iface_number %>'/>
+  <% end %>
+  <alias name='net<%= @iface_number %>'/>
   <model type='<%=@model_type%>'/>
 </interface>


### PR DESCRIPTION
Allow the user to specify what the domif name will be for an interface
by defining a name in the Vagrantfile. This allows one to later build link
toggling from within vagrant or easily toggle the link using virsh. An
example using virsh.

By default the name of tunnel interfaces will be "tnet" + interface
number.

Given a Vagrantfile snippet:
    node.vm.network :private_network,
          :libvirt__tunnel_type => 'udp',
          :libvirt__tunnel_port => 8001,
          :libvirt__tunnel_local_port =>  8002,
          :libvirt__iface_name => 'test1'

Generates named domain interface called 'test1':
    $ virsh -c qemu:///system  domiflist vagrant_default
    Interface  Type       Source     Model       MAC
    -------------------------------------------------------
    vnet0      network    vagrant-libvirt virtio      52:54:00:2f:c1:82
    vnet1      network    switch_mgmt virtio      12:11:22:33:44:11
    test1      udp        -          virtio      52:54:00:7d:8a:2a
    tnet3      udp        -          virtio      52:54:00:ec:39:12

To toggle the interface link status one can do the following, toggle
the link up:
    $ virsh -c qemu:///system domif-setlink vagrant_default test1 up
    $ vagrant ssh -- sudo ip link set eth2 up
    $ vagrant ssh -- ip link show eth2
    4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast
    state UP mode DEFAULT group default qlen 1000
        link/ether 52:54:00:7d:8a:2a brd ff:ff:ff:ff:ff:ff

Toggle the link down:
    $ virsh -c qemu:///system domif-setlink vagrant_default test1 down
    $ vagrant ssh -- sudo ip link set eth2 up
    $ vagrant ssh -- ip link show eth2
    4: eth2: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc pfifo_fast
    state DOWN mode DEFAULT group default qlen 1000
        link/ether 52:54:00:7d:8a:2a brd ff:ff:ff:ff:ff:ff

Signed-off-by: Jonathan Toppins <jtoppins@cumulusnetworks.com>