### PR TITLE
Fix wrong interpolation argument

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -53,7 +53,7 @@ en:
     warnings:
       ignoring_virtual_size_too_small: |-
         Ignoring requested virtual disk size of '%{requested}' as it is below
-        the minimum box image size of '%{box_virtual_size}'.
+        the minimum box image size of '%{minimum}'.
 
     errors:
       package_not_supported: No support for package with libvirt. Create box manually.


### PR DESCRIPTION
This caused an ugly stacktrace when the requested virtual size is
smaller than the actual image size.