### PR TITLE
Allow dots in domain_name

### DIFF
--- a/lib/vagrant-libvirt/action/set_name_of_domain.rb
+++ b/lib/vagrant-libvirt/action/set_name_of_domain.rb
@@ -54,7 +54,7 @@ module VagrantPlugins
               config.default_prefix.to_s.concat("_")
             end
           domain_name << env[:machine].name.to_s
-          domain_name.gsub!(/[^-a-z0-9_]/i, '')
+          domain_name.gsub!(/[^-a-z0-9_\.]/i, '')
           domain_name << "_#{Time.now.utc.to_i}_#{SecureRandom.hex(10)}" if config.random_hostname
           domain_name
         end


### PR DESCRIPTION
As we are sometimes using FQDNs as box names, it would be nice to keep the dots. 
I tested this minor change on version 0.0.32 and it creates domain/disk correctly. 

If you need me to do anything else, just let me know. Thanks