### PR TITLE
Allow disabling guest-to-guest ipv6 comms in libvirt networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,8 @@ starts with 'libvirt__' string. Here is a list of those options:
 * `:libvirt__tunnel_local_ip` - Sets the local IP used by the udp tunnel
     interface type. It populates the ip entry of the `<local address=XXX">` section of
     the interface xml configuration. _(This feature only works in libvirt 1.2.20 and higher)_
+* `:libvirt__guest_ipv6` - Enable or disable guest-to-guest IPv6 communication.
+    See [here](https://libvirt.org/formatnetwork.html#examplesPrivate6), and [here](http://libvirt.org/git/?p=libvirt.git;a=commitdiff;h=705e67d40b09a905cd6a4b8b418d5cb94eaa95a8) for for more information.
 * `:mac` - MAC address for the interface.
 * `:model_type` - parameter specifies the model of the network adapter when you create a domain value by default virtio KVM believe possible values, see the documentation for libvirt
 
@@ -425,6 +427,7 @@ configurable at the provider level.
 
 * `management_network_name` - Name of libvirt network to which all VMs will be connected. If not specified the default is 'vagrant-libvirt'.
 * `management_network_address` - Address of network to which all VMs will be connected. Must include the address and subnet mask. If not specified the default is '192.168.121.0/24'.
+* `management_network_guest_ipv6` - Enable or disable guest-to-guest IPv6 communication. See [here](https://libvirt.org/formatnetwork.html#examplesPrivate6), and [here](http://libvirt.org/git/?p=libvirt.git;a=commitdiff;h=705e67d40b09a905cd6a4b8b418d5cb94eaa95a8) for for more information.
 
 You may wonder how vagrant-libvirt knows the IP address a VM received.
 Libvirt doesn't provide a standard way to find out the IP address of a running

--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -58,6 +58,7 @@ module VagrantPlugins
                 created:          false,
                 active:           false,
                 autostart:        false,
+                guest_ipv6:       @options[:guest_ipv6] || 'yes',
                 libvirt_network:  nil
               }
 
@@ -270,6 +271,7 @@ module VagrantPlugins
           @network_bridge_name = @interface_network[:bridge_name]
           @network_address = @interface_network[:ip_address]
           @network_netmask = @interface_network[:netmask]
+          @guest_ipv6 = @interface_network[:guest_ipv6]
 
           @network_forward_mode = @options[:forward_mode]
           if @options[:forward_device]

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -48,6 +48,7 @@ module VagrantPlugins
       attr_accessor :management_network_address
       attr_accessor :management_network_mode
       attr_accessor :management_network_mac
+      attr_accessor :management_network_guest_ipv6
 
       # Default host prefix (alternative to use project folder name)
       attr_accessor :default_prefix
@@ -110,6 +111,7 @@ module VagrantPlugins
         @management_network_address = UNSET_VALUE
         @management_network_mode = UNSET_VALUE
         @management_network_mac  = UNSET_VALUE
+        @management_network_guest_ipv6  = UNSET_VALUE
 
         # Domain specific settings.
         @uuid              = UNSET_VALUE
@@ -342,6 +344,7 @@ module VagrantPlugins
         @management_network_address = '192.168.121.0/24' if @management_network_address == UNSET_VALUE
         @management_network_mode = 'nat' if @management_network_mode == UNSET_VALUE
         @management_network_mac = nil if @management_network_mac == UNSET_VALUE
+        @management_network_guest_ipv6 = 'yes' if @management_network_guest_ipv6 == UNSET_VALUE
 
         # generate a URI if none is supplied
         @uri = _generate_uri() if @uri == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/private_network.xml.erb
+++ b/lib/vagrant-libvirt/templates/private_network.xml.erb
@@ -1,4 +1,4 @@
-<network ipv6='yes'>
+<network ipv6='<%= @guest_ipv6 %>'>
   <name><%= @network_name %></name>
   <bridge name="<%= @network_bridge_name %>" />
 

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -12,6 +12,7 @@ module VagrantPlugins
           management_network_address = env[:machine].provider_config.management_network_address
           management_network_mode = env[:machine].provider_config.management_network_mode
           management_network_mac = env[:machine].provider_config.management_network_mac
+          management_network_guest_ipv6 = env[:machine].provider_config.management_network_guest_ipv6
           logger.info "Using #{management_network_name} at #{management_network_address} as the management network #{management_network_mode} is the mode"
 
           begin
@@ -36,6 +37,7 @@ module VagrantPlugins
             netmask: $2,
             dhcp_enabled: true,
             forward_mode: management_network_mode,
+            guest_ipv6: management_network_guest_ipv6,
           }
 
           unless management_network_mac.nil?


### PR DESCRIPTION
Background
----------
The default private_network template we supply has the following tag:

    <network ipv6='yes'>

This enables ipv6 on guest interfaces for guest-to-guest communication.
This causes a problem on hosts that either do not have ipv6 enabled or
configured correctly, resulting in an error on 'vagrant up' as follows:

    Error while activating network: Call to virNetworkCreate failed: internal error: Failed to apply firewall rules /usr/sbin/ip6tables --table filter --insert FORWARD --in-interface virbr1 --jump REJECT: ip6tables v1.4.21: can't initialize ip6tables table `filter': Address family not supported by protocol
    Perhaps ip6tables or your kernel needs to be upgraded.

Reading here:
http://libvirt.org/git/?p=libvirt.git;a=commitdiff;h=705e67d40b09a905cd6a4b8b418d5cb94eaa95a8
would suggest the above option should really be off by default, however,
I don't want to break existing behaviour or setups. This patch adds two
new config items, one for the default management network, and one for
additional user defined private networks.

Usage
-----
To disable ipv6 for the managment network:

    config.vm.provider :libvirt do |libvirt|
        libvirt.management_network_guest_ipv6 = "no"
    end

To disable for a custom private network:

    config.vm.network "private_network", ip: "192.168.33.10", libvirt__guest_ipv6: "no"

Extra Notes:
------------
Also note, if you get hit by the above error and want to apply the above
fix, you will need to clear out the management network manually:

    $ sudo virsh net-list --all
    Name                 State      Autostart     Persistent
    ----------------------------------------------------------
    default              active     yes           yes
    vagrant-libvirt      inactive   no            yes

    $ sudo virsh net-undefine vagrant-libvirt
    Network vagrant-libvirt has been undefined