### PR TITLE
Bugfix: Config.finalize!: set @pcis if UNSET_VALUE

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -389,6 +389,9 @@ module VagrantPlugins
         # Inputs
         @inputs = [{:type => "mouse", :bus => "ps2"}] if @inputs == UNSET_VALUE
 
+        # PCI device passthrough
+        @pcis = [] if @pcis == UNSET_VALUE
+
         # Suspend mode
         @suspend_mode = "pause" if @suspend_mode == UNSET_VALUE
 


### PR DESCRIPTION
Fixes this fine backtrace:

```
/home/fxkr/.vagrant.d/gems/gems/vagrant-libvirt-0.0.32/lib/vagrant-libvirt/action/create_domain.rb:194:in `call': undefined method `each' for #<Object:0x00560de1a102a8> (NoMethodError)
	from /usr/share/vagrant/lib/vagrant/action/warden.rb:34:in `call'
	from /home/fxkr/.vagrant.d/gems/gems/vagrant-libvirt-0.0.32/lib/vagrant-libvirt/action/create_domain_volume.rb:51:in `call'
	from /usr/share/vagrant/lib/vagrant/action/warden.rb:34:in `call'
	from /home/fxkr/.vagrant.d/gems/gems/vagrant-libvirt-0.0.32/lib/vagrant-libvirt/action/handle_box_image.rb:109:in `call'
	from /usr/share/vagrant/lib/vagrant/action/warden.rb:34:in `call'
	from /usr/share/vagrant/lib/vagrant/action/builtin/handle_box.rb:56:in `call'
	from /usr/share/vagrant/lib/vagrant/action/warden.rb:34:in `call'
	from /home/fxkr/.vagrant.d/gems/gems/vagrant-libvirt-0.0.32/lib/vagrant-libvirt/action/handle_storage_pool.rb:50:in `call'
	from /usr/share/vagrant/lib/vagrant/action/warden.rb:34:in `call'
	from /home/fxkr/.vagrant.d/gems/gems/vagrant-libvirt-0.0.32/lib/vagrant-libvirt/action/set_name_of_domain.rb:35:in `call'
	from /usr/share/vagrant/lib/vagrant/action/warden.rb:34:in `call'
	from /usr/share/vagrant/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
	from /usr/share/vagrant/lib/vagrant/action/warden.rb:34:in `call'
	from /usr/share/vagrant/lib/vagrant/action/warden.rb:34:in `call'
	from /usr/share/vagrant/lib/vagrant/action/builder.rb:116:in `call'
	from /usr/share/vagrant/lib/vagrant/action/runner.rb:66:in `block in run'
	from /usr/share/vagrant/lib/vagrant/util/busy.rb:19:in `busy'
	from /usr/share/vagrant/lib/vagrant/action/runner.rb:66:in `run'
	from /usr/share/vagrant/lib/vagrant/action/builtin/call.rb:53:in `call'
	from /usr/share/vagrant/lib/vagrant/action/warden.rb:34:in `call'
	from /usr/share/vagrant/lib/vagrant/action/builtin/config_validate.rb:25:in `call'
	from /usr/share/vagrant/lib/vagrant/action/warden.rb:34:in `call'
	from /usr/share/vagrant/lib/vagrant/action/builder.rb:116:in `call'
	from /usr/share/vagrant/lib/vagrant/action/runner.rb:66:in `block in run'
	from /usr/share/vagrant/lib/vagrant/util/busy.rb:19:in `busy'
	from /usr/share/vagrant/lib/vagrant/action/runner.rb:66:in `run'
	from /usr/share/vagrant/lib/vagrant/machine.rb:214:in `action_raw'
	from /usr/share/vagrant/lib/vagrant/machine.rb:191:in `block in action'
	from /usr/share/vagrant/lib/vagrant/environment.rb:516:in `lock'
	from /usr/share/vagrant/lib/vagrant/machine.rb:178:in `call'
	from /usr/share/vagrant/lib/vagrant/machine.rb:178:in `action'
	from /usr/share/vagrant/lib/vagrant/batch_action.rb:82:in `block (2 levels) in run'
```

(The vagrant-libvirt in that backtrace is actually a self-built current git version.)