### PR TITLE
Added machine memory string to integer conversion

### DIFF
--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -23,8 +23,8 @@ module VagrantPlugins
 
             libvirt_domain =  env[:machine].provider.driver.connection.client.lookup_domain_by_uuid(env[:machine].id)
 
-            if config.memory*1024 != libvirt_domain.max_memory
-              libvirt_domain.max_memory = config.memory*1024
+            if config.memory.to_i*1024 != libvirt_domain.max_memory
+              libvirt_domain.max_memory = config.memory.to_i*1024
               libvirt_domain.memory = libvirt_domain.max_memory
             end
             begin


### PR DESCRIPTION
This is regarding https://github.com/pradels/vagrant-libvirt/issues/525 if there are quotes on memory it gets a type error when starting the domain