### PR TITLE
Fix network interface configuration for windows guests

### DIFF
--- a/lib/vagrant-libvirt/cap/nic_mac_addresses.rb
+++ b/lib/vagrant-libvirt/cap/nic_mac_addresses.rb
@@ -3,7 +3,13 @@ module VagrantPlugins
     module Cap
       class NicMacAddresses
         def self.nic_mac_addresses(machine)
-          machine.provider.mac_addresses
+          # Vagrant expects a Hash with an index starting at 1 as key
+          # and the mac as uppercase string without colons as value
+          nic_macs = {}
+          machine.provider.mac_addresses.each do |index, mac|
+            nic_macs[index+1] = mac.upcase.gsub(':','')
+          end
+          nic_macs
         end
       end
     end


### PR DESCRIPTION
Change the return format of the nic_mac_addresses capability to comply with the format expected by Vagrant:
> Vagrant expects a hash with an index starting at 1 as key
> and the mac as uppercase string without colons as value


This fixes the configuration of additional network interfaces for Windows guests. Other guests don't require the mac address of a interface to configure it, thus this only affected windows guests.

The expected format was also discussed in the [vagrant-parallels plugin](https://github.com/Parallels/vagrant-parallels/issues/170).

I hope the pull request is ok like that. Just tell me if there is something missing, I'll gladly fix it.