### PR TITLE
Allow to forward ports from a custom adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,8 @@ you want the forwarded port to be accessible from outside the Vagrant
 host.  In this case you should also set the `host_ip` option to `'*'`
 since it defaults to `'localhost'`.
 
+You can also provide a custom adapter to forward from by 'adapter' option. Default is 'eth0'.
+
 ## Synced Folders
 
 vagrant-libvirt supports bidirectional synced folders via nfs or 9p and

--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -38,7 +38,7 @@ module VagrantPlugins
         def forward_ports
           @env[:forwarded_ports].each do |fp|
             message_attributes = {
-              adapter: 'eth0',
+              adapter: fp[:adapter] || 'eth0',
               guest_port: fp[:guest],
               host_port: fp[:host]
             }


### PR DESCRIPTION
Before this change, vagrant-libvirt assumed that all port forwards should be done on eth0 adapter. Now user can provide a custom adapter via "adapter" option when calling forwarded_port.