### PR TITLE
Added basic support for CPU features

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -33,6 +33,7 @@ module VagrantPlugins
           @name = env[:domain_name]
           @uuid = config.uuid
           @cpus = config.cpus.to_i
+          @cpu_features = config.cpu_features
           @cpu_mode = config.cpu_mode
           @loader = config.loader
           @machine_type = config.machine_type
@@ -150,6 +151,9 @@ module VagrantPlugins
           end
           env[:ui].info(" -- Domain type:       #{@domain_type}")
           env[:ui].info(" -- Cpus:              #{@cpus}")
+          @cpu_features.each do |cpu_feature|
+            env[:ui].info(" -- CPU Feature:       name=#{cpu_feature[:name]}, policy=#{cpu_feature[:policy]}")
+          end
           env[:ui].info(" -- Memory:            #{@memory_size / 1024}M")
           env[:ui].info(" -- Management MAC:    #{@management_network_mac}")
           env[:ui].info(" -- Loader:            #{@loader}")

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -58,6 +58,7 @@ module VagrantPlugins
       attr_accessor :memory
       attr_accessor :cpus
       attr_accessor :cpu_mode
+      attr_accessor :cpu_features
       attr_accessor :loader
       attr_accessor :boot_order
       attr_accessor :machine_type
@@ -128,6 +129,7 @@ module VagrantPlugins
         @memory            = UNSET_VALUE
         @cpus              = UNSET_VALUE
         @cpu_mode          = UNSET_VALUE
+        @cpu_features      = UNSET_VALUE
         @loader            = UNSET_VALUE
         @machine_type      = UNSET_VALUE
         @machine_arch      = UNSET_VALUE
@@ -207,6 +209,21 @@ module VagrantPlugins
 
         # is it better to raise our own error, or let libvirt cause the exception?
         raise 'Only four cdroms may be attached at a time'
+      end
+
+      def cpu_feature(options={})
+        if options[:name].nil? || options.[:policy].nil?
+          raise 'CPU Feature name AND policy must be specified'
+        end
+
+        if @cpu_features == UNSET_VALUE
+          @cpu_features = []
+        end
+
+        @cpu_features.push({
+          name:   options[:name],
+          policy: options[:policy]
+        })
       end
 
       def input(options={})
@@ -390,6 +407,7 @@ module VagrantPlugins
         @memory = 512 if @memory == UNSET_VALUE
         @cpus = 1 if @cpus == UNSET_VALUE
         @cpu_mode = 'host-model' if @cpu_mode == UNSET_VALUE
+        @cpu_features = [] if @cpu_features == UNSET_VALUE
         @loader = nil if @loader == UNSET_VALUE
         @machine_type = nil if @machine_type == UNSET_VALUE
         @machine_arch = nil if @machine_arch == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -12,6 +12,9 @@
         <feature policy='optional' name='vmx'/>
         <feature policy='optional' name='svm'/>
       <% end %>
+      <% @cpu_features.each do |cpu_feature| %>
+        <feature name='<%= cpu_feature[:name] %>' policy='<%= cpu_feature[:policy] %>'/>
+      <% end %>
     <% end %>
   </cpu>
 


### PR DESCRIPTION
The following option was added:

* cpu_feature - Defaults to unset, needs two options: "name" and "policy", as interpreted by libvirt

This only adds support for creating a VM with specific CPU features defined, not for changing them after the VM was created.

This is needed for Solaris support on vagrant-libvirt, since Solaris under libvirt usually needs at least one CPU feature set to "disable".