### PR TITLE
Support libvirt autostart functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ end
 * `tpm_model` - The model of the TPM to which you wish to connect.
 * `tpm_type` - The type of TPM device to which you are connecting.
 * `tpm_path` - The path to the TPM device on the host system.
+* `autostart` - Automatically start the domain when the host boots. Defaults to 'false'.
 
 
 Specific domain settings can be set for each domain separately in multi-VM

--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -208,6 +208,8 @@ module VagrantPlugins
             rescue => e
               env[:ui].error("Error when updating domain settings: #{e.message}")
             end
+            # Autostart with host if enabled in Vagrantfile
+            libvirt_domain.autostart = config.autostart
             # Actually start the domain
             domain.start
           rescue => e

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -108,6 +108,9 @@ module VagrantPlugins
       # Suspend mode
       attr_accessor :suspend_mode
 
+      # Autostart
+      attr_accessor :autostart
+
       def initialize
         @uri               = UNSET_VALUE
         @driver            = UNSET_VALUE
@@ -174,6 +177,9 @@ module VagrantPlugins
 
         # Suspend mode
         @suspend_mode      = UNSET_VALUE
+
+        # Autostart
+        @autostart         = UNSET_VALUE
       end
 
       def boot(device)
@@ -456,6 +462,8 @@ module VagrantPlugins
         # Suspend mode
         @suspend_mode = "pause" if @suspend_mode == UNSET_VALUE
 
+        # Autostart
+        @autostart = false if @autostart == UNSET_VALUE
       end
 
       def validate(machine)


### PR DESCRIPTION
Fixes #533.

I'm just not sure if we should be authoritative in setting it to `false` if not explicitly enabled in Vagrantfile - this way there is no overriding possible outside of Vagrant. 

Regardless, `false` is the default in libvirt; we can adjust if it turns out users are enabling autostart outside of vagrant and expecting that to be honored.