### PR TITLE
RFC: Drop incorrect NetworkNotAvailableError assumption for private networks.

### DIFF
--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -210,12 +210,6 @@ module VagrantPlugins
           network = lookup_network_by_name(@options[:network_name])
           @interface_network = network if network
 
-          # if this interface has a network address, something's wrong.
-          if @interface_network[:network_address]
-            raise Errors::NetworkNotAvailableError,
-                  network_name: @options[:network_name]
-          end
-
           # Do we need to create new network?
           unless @interface_network[:created]
             @interface_network[:name] = @options[:network_name]


### PR DESCRIPTION
This is probably more of an RFC than a real PR but I recently started having issues after an upgrade, my vms would no longer vagrant up. I use a custom libvirt network so I can keep them at a reliable address, and it was running afoul of this check that I'm removing with this commit. Taking it out lets me create/start my vms normally again.

Looking at the code it doesn't seem quite right to me, custom networks could easily already exist and will have an address as far as I can tell. Could easily be missing something but thought I would check and see if this should actually be removed.

More details on my issue (including Vagrantfile, custom network definition, and full error) in this bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1310802