### PR TITLE
Fix fog-libvirt version

### DIFF
--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec-expectations", "~> 2.14.0"
   gem.add_development_dependency "rspec-mocks", "~> 2.14.0"
 
-  gem.add_runtime_dependency 'fog-libvirt', '~> 0.0.1'
+  gem.add_runtime_dependency 'fog-libvirt', '0.0.3'
   gem.add_runtime_dependency 'nokogiri', '~> 1.6.0'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Recent update to `fog-`libvirt` gem causes vagrant-libvirt to fail as described in this issue https://github.com/pradels/vagrant-libvirt/issues/568

I did not have time to investigate why exactly it breaks, but fixing a version of gem that vagrant-libvirt critically relies on is important anyways.