### PR TITLE
Fix handling missing boxes 

### DIFF
--- a/lib/vagrant-libvirt/action/handle_box_image.rb
+++ b/lib/vagrant-libvirt/action/handle_box_image.rb
@@ -67,7 +67,9 @@ module VagrantPlugins
             env[:ui].info(I18n.t('vagrant_libvirt.uploading_volume'))
 
             # Create new volume in storage pool
-            raise Errors::BoxNotFound if !File.exists?(box_image_file)
+            unless File.exists?(box_image_file)
+              raise Vagrant::Errors::BoxNotFound.new(name: env[:machine].box.name)
+            end
             box_image_size = File.size(box_image_file) # B
             message = "Creating volume #{env[:box_volume_name]}"
             message << " in storage pool #{config.storage_pool_name}."


### PR DESCRIPTION
I would assume that previous implementation never worked - there is no `Errors::BoxNotFound` class defined in `vagrant-libvirt`. There is one in Vagrant itself, but wouldnt be properly loaded without my fix. As a result instead of getting correct error messae it would throw somehow misleading exception:

```
/home/kshirinkin/.vagrant.d/gems/gems/vagrant-libvirt-0.0.32/lib/vagrant-libvirt/action/handle_box_image.rb:70:in `block in call': uninitialized constant VagrantPlugins::ProviderLibvirt::Errors::BoxNotFound (NameError)
```

After this PR error message is correctly shown:

```
Bringing machine 'default' up with 'libvirt' provider...
==> default: Uploading base box image as volume into libvirt storage...
The box 'centos-base' does not exist. Please double check and
try again. You can see the boxes that are installed with
`vagrant box list`.
```