### PR TITLE
don't barf if VM has multiple identical IP addresses

### DIFF
--- a/lib/vagrant-libvirt/action/prepare_nfs_settings.rb
+++ b/lib/vagrant-libvirt/action/prepare_nfs_settings.rb
@@ -66,6 +66,7 @@ module VagrantPlugins
           end
 
           ips = result.chomp.split("\n")
+          ips = ips.uniq
           @logger.info("guest IPs: #{ips.join(', ')}")
           ips.each do |ip|
             next if ip == ssh_host

--- a/lib/vagrant-libvirt/action/prepare_nfs_settings.rb
+++ b/lib/vagrant-libvirt/action/prepare_nfs_settings.rb
@@ -65,8 +65,7 @@ module VagrantPlugins
             result << data if type == :stdout
           end
 
-          ips = result.chomp.split("\n")
-          ips = ips.uniq
+          ips = result.chomp.split("\n").uniq
           @logger.info("guest IPs: #{ips.join(', ')}")
           ips.each do |ip|
             next if ip == ssh_host


### PR DESCRIPTION
This resolves an issue when running with a VM guest which has multiple interfaces with the same IP address (yes, I know this is not orthodox).

vagrant-libvirt returns an array of guest IPs which contains duplicates, then duplicate identical lines are populated into /etc/exports, then NFS dies with:

```
Mar 07 13:42:34 jminter-t540p systemd[1]: Starting NFS server and services...
Mar 07 13:42:34 jminter-t540p exportfs[4567]: exportfs: duplicated export entries:
Mar 07 13:42:34 jminter-t540p exportfs[4567]: exportfs:         10.1.0.1:/data-ssd/home/jminter/vagrant/ose31
Mar 07 13:42:34 jminter-t540p exportfs[4567]: exportfs:         10.1.0.1:/data-ssd/home/jminter/vagrant/ose31
Mar 07 13:42:34 jminter-t540p systemd[1]: nfs-server.service: Control process exited, code=exited status=1
Mar 07 13:42:34 jminter-t540p systemd[1]: Failed to start NFS server and services.
Mar 07 13:42:34 jminter-t540p systemd[1]: nfs-server.service: Unit entered failed state.
Mar 07 13:42:34 jminter-t540p systemd[1]: nfs-server.service: Failed with result 'exit-code'.
```