### PR TITLE
ruby-dev package into missing libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ missing development libraries for libxslt, libxml2 and libvirt.
 
 In Ubuntu, Debian, ...
 ```
-$ sudo apt-get install libxslt-dev libxml2-dev libvirt-dev zlib1g-dev
+$ sudo apt-get install libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
 ```
 
 In RedHat, Centos, Fedora, ...
 ```
-# yum install libxslt-devel libxml2-devel libvirt-devel libguestfs-tools-c
+# yum install libxslt-devel libxml2-devel libvirt-devel libguestfs-tools-c ruby-devel
 ```
 
 If have problem with installation - check your linker. It should be ld.gold:


### PR DESCRIPTION
i tried to install on a fresh ubuntu 14.04, installation did not work unless adding ruby-dev. it failed with error below:

```bash
# vagrant plugin install vagrant-libvirt
Installing the 'vagrant-libvirt' plugin. This can take a few minutes...
/usr/lib/ruby/1.9.1/rubygems/installer.rb:562:in `rescue in block in build_extensions': ERROR: Failed to build gem native extension. (Gem::Installer::ExtensionBuildError)

        /usr/bin/ruby1.9.1 extconf.rb
/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- mkmf (LoadError)
	from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
	from extconf.rb:4:in `<main>'


Gem files will remain installed in /root/.vagrant.d/gems/gems/nokogiri-1.6.7.2 for inspection.
Results logged to /root/.vagrant.d/gems/gems/nokogiri-1.6.7.2/ext/nokogiri/gem_make.out
	from /usr/lib/ruby/1.9.1/rubygems/installer.rb:540:in `block in build_extensions'
	from /usr/lib/ruby/1.9.1/rubygems/installer.rb:515:in `each'
	from /usr/lib/ruby/1.9.1/rubygems/installer.rb:515:in `build_extensions'
	from /usr/lib/ruby/1.9.1/rubygems/installer.rb:180:in `install'
	from /usr/lib/ruby/1.9.1/rubygems/dependency_installer.rb:297:in `block in install'
	from /usr/lib/ruby/1.9.1/rubygems/dependency_installer.rb:270:in `each'
	from /usr/lib/ruby/1.9.1/rubygems/dependency_installer.rb:270:in `each_with_index'
	from /usr/lib/ruby/1.9.1/rubygems/dependency_installer.rb:270:in `install'
	from /usr/share/vagrant/plugins/commands/plugin/action/install_gem.rb:65:in `block in call'
	from /usr/share/vagrant/plugins/commands/plugin/gem_helper.rb:42:in `block in with_environment'
	from /usr/lib/ruby/1.9.1/rubygems/user_interaction.rb:40:in `use_ui'
	from /usr/share/vagrant/plugins/commands/plugin/gem_helper.rb:41:in `with_environment'
	from /usr/share/vagrant/plugins/commands/plugin/action/install_gem.rb:52:in `call'
	from /usr/lib/ruby/vendor_ruby/vagrant/action/warden.rb:34:in `call'
	from /usr/share/vagrant/plugins/commands/plugin/action/bundler_check.rb:20:in `call'
	from /usr/lib/ruby/vendor_ruby/vagrant/action/warden.rb:34:in `call'
	from /usr/lib/ruby/vendor_ruby/vagrant/action/builder.rb:116:in `call'
	from /usr/lib/ruby/vendor_ruby/vagrant/action/runner.rb:69:in `block in run'
	from /usr/lib/ruby/vendor_ruby/vagrant/util/busy.rb:19:in `busy'
	from /usr/lib/ruby/vendor_ruby/vagrant/action/runner.rb:69:in `run'
	from /usr/share/vagrant/plugins/commands/plugin/command/base.rb:17:in `action'
	from /usr/share/vagrant/plugins/commands/plugin/command/install.rb:27:in `execute'
	from /usr/share/vagrant/plugins/commands/plugin/command/root.rb:56:in `execute'
	from /usr/lib/ruby/vendor_ruby/vagrant/cli.rb:38:in `execute'
	from /usr/lib/ruby/vendor_ruby/vagrant/environment.rb:484:in `cli'
	from /usr/bin/vagrant:127:in `<main>'
```