### PR TITLE
Add cpu_model and cpu_fallback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,9 @@ end
 * `memory` - Amount of memory in MBytes. Defaults to 512 if not set.
 * `cpus` - Number of virtual cpus. Defaults to 1 if not set.
 * `nested` - [Enable nested virtualization](https://github.com/torvalds/linux/blob/master/Documentation/virtual/kvm/nested-vmx.txt). Default is false.
-* `cpu_mode` - [CPU emulation mode](https://libvirt.org/formatdomain.html#elementsCPU). Defaults to 'host-model' if not set. Allowed values: host-model, host-passthrough.
+* `cpu_mode` - [CPU emulation mode](https://libvirt.org/formatdomain.html#elementsCPU). Defaults to 'host-model' if not set. Allowed values: host-model, host-passthrough, custom.
+* `cpu_model` - CPU Model. Defaults to 'qemu64' if not set. This can really only be used when setting `cpu_mode` to `custom`.
+* `cpu_fallback` - Whether to allow libvirt to fall back to a CPU model close to the specified model if features in the guest CPU are not supported on the host. Defaults to 'allow' if not set. Allowed values: `allow`, `forbid`.
 * `loader` - Sets path to custom UEFI loader.
 * `volume_cache` - Controls the cache mechanism. Possible values are "default", "none", "writethrough", "writeback", "directsync" and "unsafe". [See driver->cache in libvirt documentation](http://libvirt.org/formatdomain.html#elementsDisks).
 * `kernel` - To launch the guest with a kernel residing on host filesystems. Equivalent to qemu `-kernel`.

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -35,6 +35,8 @@ module VagrantPlugins
           @cpus = config.cpus.to_i
           @cpu_features = config.cpu_features
           @cpu_mode = config.cpu_mode
+          @cpu_model = config.cpu_model
+          @cpu_fallback = config.cpu_fallback
           @loader = config.loader
           @machine_type = config.machine_type
           @machine_arch = config.machine_arch

--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -88,7 +88,16 @@ module VagrantPlugins
                   descr_changed = true
                   cpu_model = REXML::Element.new('model', REXML::XPath.first(xml_descr,'/domain/cpu'))
                   cpu_model.attributes['fallback'] = 'allow'
-                  cpu_model.text = 'qemu64'
+                  cpu_model.text = config.cpu_model
+                else
+                  if cpu_model.text != config.cpu_model
+                    descr_changed = true
+                    cpu_model.text = config.cpu_model
+                  end
+                  if cpu_model.attributes['fallback'] != config.cpu_fallback
+                    descr_changed = true
+                    cpu_model.attributes['fallback'] = config.cpu_fallback
+                  end
                 end
                 vmx_feature = REXML::XPath.first(xml_descr,'/domain/cpu/feature[@name="vmx"]')
                 svm_feature = REXML::XPath.first(xml_descr,'/domain/cpu/feature[@name="svm"]')

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -58,6 +58,8 @@ module VagrantPlugins
       attr_accessor :memory
       attr_accessor :cpus
       attr_accessor :cpu_mode
+      attr_accessor :cpu_model
+      attr_accessor :cpu_fallback
       attr_accessor :cpu_features
       attr_accessor :loader
       attr_accessor :boot_order
@@ -133,6 +135,8 @@ module VagrantPlugins
         @memory            = UNSET_VALUE
         @cpus              = UNSET_VALUE
         @cpu_mode          = UNSET_VALUE
+        @cpu_model         = UNSET_VALUE
+        @cpu_fallback      = UNSET_VALUE
         @cpu_features      = UNSET_VALUE
         @loader            = UNSET_VALUE
         @machine_type      = UNSET_VALUE
@@ -415,6 +419,8 @@ module VagrantPlugins
         @memory = 512 if @memory == UNSET_VALUE
         @cpus = 1 if @cpus == UNSET_VALUE
         @cpu_mode = 'host-model' if @cpu_mode == UNSET_VALUE
+        @cpu_model = 'qemu64' if @cpu_model == UNSET_VALUE
+        @cpu_fallback = 'allow' if @cpu_fallback == UNSET_VALUE
         @cpu_features = [] if @cpu_features == UNSET_VALUE
         @loader = nil if @loader == UNSET_VALUE
         @machine_type = nil if @machine_type == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -7,7 +7,7 @@
 
   <cpu mode='<%= @cpu_mode %>'>
     <% if @cpu_mode != 'host-passthrough' %>
-      <model fallback='allow'>qemu64</model>
+      <model fallback='<%= @cpu_fallback %>'><%= @cpu_model %></model>
       <% if @nested %>
         <feature policy='optional' name='vmx'/>
         <feature policy='optional' name='svm'/>


### PR DESCRIPTION
This allows for specific CPU selection and enforcement when cpu_mode =
custom, which is important when emulating CPUs of different architecture
than the host.