### PR TITLE
Move version sanity check to vagrant-libvirt.rb

### DIFF
--- a/lib/vagrant-libvirt.rb
+++ b/lib/vagrant-libvirt.rb
@@ -13,5 +13,11 @@ module VagrantPlugins
   end
 end
 
+# This is a sanity check to make sure no one is attempting to install
+# this into an early Vagrant version.
+if Vagrant::VERSION < '1.5.0'
+  raise 'The Vagrant Libvirt plugin is only compatible with Vagrant 1.5+'
+end
+
 # make sure base module class defined before loading plugin
 require 'vagrant-libvirt/plugin'

--- a/lib/vagrant-libvirt.rb
+++ b/lib/vagrant-libvirt.rb
@@ -13,6 +13,12 @@ module VagrantPlugins
   end
 end
 
+begin
+  require 'vagrant'
+rescue LoadError
+  raise 'The Vagrant Libvirt plugin must be run within Vagrant.'
+end
+
 # This is a sanity check to make sure no one is attempting to install
 # this into an early Vagrant version.
 if Vagrant::VERSION < '1.5.0'

--- a/lib/vagrant-libvirt/plugin.rb
+++ b/lib/vagrant-libvirt/plugin.rb
@@ -4,12 +4,6 @@ rescue LoadError
   raise 'The Vagrant Libvirt plugin must be run within Vagrant.'
 end
 
-# This is a sanity check to make sure no one is attempting to install
-# this into an early Vagrant version.
-if Vagrant::VERSION < '1.5.0'
-  raise 'The Vagrant Libvirt plugin is only compatible with Vagrant 1.5+'
-end
-
 # compatibility fix to define constant not available vagrant <1.6
 ::Vagrant::MachineState::NOT_CREATED_ID ||= :not_created
 


### PR DESCRIPTION
If this check is executed in plugin.rb, the message is not displayed on
older versions of vagrant, which defeats the purpose of the test.

This should fix #586 